### PR TITLE
Add the option to change X509IncludeOption during SAMLResponse signing

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/XMLSignatureExtensions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/XMLSignatureExtensions.cs
@@ -77,7 +77,7 @@ public static class XMLSignatureExtensions
     /// <param name="doc">The XmlDocument to be signed</param>
     /// <param name="id">The id of the topmost element in the XmlDocument</param>
     /// <param name="cert">The certificate used to sign the document</param>
-    public static SignedXml SignDocument(this XmlDocument doc, string id, X509Certificate2 cert, string digestMethod)
+    public static SignedXml SignDocument(this XmlDocument doc, string id, X509Certificate2 cert, string digestMethod, X509IncludeOption x509IncludeOption = X509IncludeOption.EndCertOnly)
     {
         var signedXml = new SignedXml(doc);
         signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
@@ -93,7 +93,7 @@ public static class XMLSignatureExtensions
 
         // Include the public key of the certificate in the assertion.
         signedXml.KeyInfo = new KeyInfo();
-        signedXml.KeyInfo.AddClause(new KeyInfoX509Data(cert, X509IncludeOption.WholeChain));
+        signedXml.KeyInfo.AddClause(new KeyInfoX509Data(cert, x509IncludeOption));
         reference.DigestMethod = digestMethod;
 
         signedXml.ComputeSignature();

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/FederatorOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/FederatorOptions.cs
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+using System.Security.Cryptography.X509Certificates;
+
 namespace Microsoft.SPID.Proxy.Models.Options;
 
 public class FederatorOptions
@@ -11,4 +13,5 @@ public class FederatorOptions
     public string SPIDEntityId { get; set; }
     public string EntityId { get; set; }
     public string FederatorAttributeConsumerServiceUrl { get; set; }
+    public X509IncludeOption X509IncludeOption { get; set; } = X509IncludeOption.EndCertOnly;
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorResponseService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorResponseService.cs
@@ -224,7 +224,7 @@ public class FederatorResponseService : IFederatorResponseService
     {
         var responseId = doc.DocumentElement.Attributes["ID"].Value;
         var cert = await _certificateService.GetProxySignCertificate();
-        var signedXml = doc.SignDocument(responseId, cert, responseDigestMethod);
+        var signedXml = doc.SignDocument(responseId, cert, responseDigestMethod, _federatorOptions.X509IncludeOption);
 
         // Append the computed signature. The signature must be placed as the sibling of the Issuer element.
         XmlNodeList nodes = doc.DocumentElement.GetElementsByTagName("Status", Saml20Constants.PROTOCOL);
@@ -235,7 +235,7 @@ public class FederatorResponseService : IFederatorResponseService
     {
         var assertionId = doc.GetElementsByTagName("Assertion", Saml20Constants.ASSERTION)[0].Attributes["ID"].Value;
         var cert = await _certificateService.GetProxySignCertificate();
-        var signedXml = doc.SignDocument(assertionId, cert, assertionDigestMethod);
+        var signedXml = doc.SignDocument(assertionId, cert, assertionDigestMethod, _federatorOptions.X509IncludeOption);
 
         // Append the computed signature. The signature must be placed as the sibling of the Issuer element.
         XmlNodeList nodes = doc.DocumentElement.GetElementsByTagName("Issuer", Saml20Constants.ASSERTION);

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -40,7 +40,8 @@
 		"MetadataUrl": "https://your.adfs.metadata.url/FederationMetadata/2007-06/FederationMetadata.xml",
 		"SPIDEntityId": "https://your.adfs.url/adfs/services/trust",
 		"EntityId": "https://your.adfs.url/adfs/services/trust",
-		"FederatorAttributeConsumerServiceUrl": "https://adfs.url/adfs/ls"
+		"FederatorAttributeConsumerServiceUrl": "https://adfs.url/adfs/ls",
+		"X509IncludeOption": "EndCertOnly"
 	},
 	"spid": {
 		"DefaultSPIDL": 1,


### PR DESCRIPTION
Adding the option to change the X509IncludeOption during SAMLResponse signing. Default is EndCertOnly.
We can override the value using the setting Federator__X509IncludeOption which is a [System.Security.Cryptography.X509Certificates.X509IncludeOption](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509includeoption?view=net-6.0).

Closes #17 