### PR TITLE
Add configurable StoreLocation for SigningCertificate

### DIFF
--- a/WebApps/CNS.Auth.Web/Services/SAMLService.cs
+++ b/WebApps/CNS.Auth.Web/Services/SAMLService.cs
@@ -263,5 +263,7 @@ namespace CNS.Auth.Web.Services
 		public X509Certificate2 SigningCertificate { get; set; }
 		public string ResponseIssuer { get; set; }
 		public string SSOLocation { get; set; }
+		public string SigningCertificateThumbprint { get; set; }
+		public StoreLocation StoreLocation { get; set; } = StoreLocation.CurrentUser;
 	}
 }

--- a/WebApps/CNS.Auth.Web/Startup.cs
+++ b/WebApps/CNS.Auth.Web/Startup.cs
@@ -70,21 +70,22 @@ namespace CNS.Auth.Web
 
 			services.Configure<SAMLServiceOptions>(options =>
 			{
-				var certThumbprint = Configuration["SAMLService:SigningCertificateThumbprint"];
-				using (X509Store certStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+				Configuration.Bind("SAMLService", options);
+
+				using (X509Store certStore = new X509Store(StoreName.My, options.StoreLocation))
 				{
 					certStore.Open(OpenFlags.ReadOnly);
 
 					X509Certificate2Collection certCollection = certStore.Certificates.Find(
 												X509FindType.FindByThumbprint,
-												certThumbprint,
+												options.SigningCertificateThumbprint,
 												false);
 					// Get the first cert with the thumbprint (should be only one)
 					var signingCert = certCollection.OfType<X509Certificate2>().FirstOrDefault();
 
 					if (signingCert is null)
-						throw new Exception($"Certificate with thumbprint {certThumbprint} was not found");
-					Configuration.Bind("SAMLService", options);
+						throw new Exception($"Certificate with thumbprint {options.SigningCertificateThumbprint} was not found");
+					
 					options.SigningCertificate = signingCert;
 				}
 			});

--- a/WebApps/CNS.Auth.Web/appsettings.json
+++ b/WebApps/CNS.Auth.Web/appsettings.json
@@ -1,31 +1,32 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
-        },
-        "ApplicationInsights": {
-            "LogLevel": {
-                "Default": "Information"
-            }
-        }
-    },
-    "AllowedHosts": "*",
-    "CNSCertificate": {
-        "ValidCertificatePolicies": [ "1.3.76.47.4", "1.3.76.16.2.1" ],
-        "TrustedListFileUrl": "https://eidas.agid.gov.it/TL/TSL-IT.xml",
-        "LogCertificate": true,
-        "LogSubject": true,
-        "BlockIfMissingGivenNameOrSurname": false
-    },
-    "CertificateForwarding": {
-        "CertificateHeaderName": "X-ARR-ClientCert",
-        "IsCertUrlEncoded": false
-    },
-    "SAMLService": {
-        "SigningCertificateThumbprint": "f661b62b33233ab68b51aa1fa85ba18507ba634a",
-        "ResponseIssuer": "http://microsoft.com/premier/cns",
-        "SSOLocation": "https://samlcns.azurewebsites.net/CNS/sso"
-    }
+	"Logging": {
+		"LogLevel": {
+			"Default": "Information",
+			"Microsoft": "Warning",
+			"Microsoft.Hosting.Lifetime": "Information"
+		},
+		"ApplicationInsights": {
+			"LogLevel": {
+				"Default": "Information"
+			}
+		}
+	},
+	"AllowedHosts": "*",
+	"CNSCertificate": {
+		"ValidCertificatePolicies": [ "1.3.76.47.4", "1.3.76.16.2.1" ],
+		"TrustedListFileUrl": "https://eidas.agid.gov.it/TL/TSL-IT.xml",
+		"LogCertificate": true,
+		"LogSubject": true,
+		"BlockIfMissingGivenNameOrSurname": false
+	},
+	"CertificateForwarding": {
+		"CertificateHeaderName": "X-ARR-ClientCert",
+		"IsCertUrlEncoded": false
+	},
+	"SAMLService": {
+		"SigningCertificateThumbprint": "f661b62b33233ab68b51aa1fa85ba18507ba634a",
+		"ResponseIssuer": "http://microsoft.com/premier/cns",
+		"SSOLocation": "https://samlcns.azurewebsites.net/CNS/sso",
+		"StoreLocation": "CurrentUser"
+	}
 }


### PR DESCRIPTION
- Default StoreLocation is CurrentUser (required on Azure App Service)
- You can also specify LocalMachine, which is useful on IIS with AppPoolIdentity

Fixes: #26 