### PR TITLE
Support reverse proxies

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Controllers/ProxyController.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Controllers/ProxyController.cs
@@ -15,6 +15,7 @@ public class ProxyController : Controller
 	private readonly ILogAccessService _logAccessService;
 	private readonly IFederatorResponseService _federatorResponseService;
 	private readonly IFederatorRequestService _federatorRequestService;
+	private readonly ISAMLService _samlService;
 	private readonly FederatorOptions _federatorOptions;
 	private readonly TechnicalChecksOptions _technicalChecksOptions;
 
@@ -22,6 +23,7 @@ public class ProxyController : Controller
 		ILogAccessService logAccessService,
 		IFederatorResponseService federatorResponseService,
 		IFederatorRequestService federatorRequestService,
+		ISAMLService samlService,
 		IOptions<FederatorOptions> federatorOptions,
 		IOptions<TechnicalChecksOptions> technicalChecksOptions)
 	{
@@ -29,6 +31,7 @@ public class ProxyController : Controller
 		_logAccessService = logAccessService;
 		_federatorResponseService = federatorResponseService;
 		_federatorRequestService = federatorRequestService;
+		_samlService = samlService;
 		_federatorOptions = federatorOptions.Value;
 		_technicalChecksOptions = technicalChecksOptions.Value;
 	}
@@ -163,7 +166,7 @@ public class ProxyController : Controller
 				_logger.LogDebug("Removing NameQualifier from Issuer");
 				_logger.LogDebug("Setting new SubjectConfirmationData.Recipient = {newRecipient}", _federatorOptions.FederatorAttributeConsumerServiceUrl);
 				responseXml.AlterAudience(_federatorOptions.EntityId)
-					.AlterDestination(_federatorOptions.FederatorAttributeConsumerServiceUrl, HttpContext.Request.Host.ToString(), _technicalChecksOptions.SkipTechnicalChecks)
+					.AlterDestination(_federatorOptions.FederatorAttributeConsumerServiceUrl, _samlService.GetAttributeConsumerService(), _technicalChecksOptions.SkipTechnicalChecks)
 					.AlterSubjectConfirmation(_federatorOptions.FederatorAttributeConsumerServiceUrl)
 					.RemoveNameQualifierIfFormatEntity();
 

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/ResponseSAMLAsXMLExtensions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/ResponseSAMLAsXMLExtensions.cs
@@ -43,18 +43,18 @@ public static class ResponseSAMLAsXMLExtensions
 	}
 
 	public static XmlDocument AlterDestination(this XmlDocument samlResponse,
-		string attributeConsumerServiceUrl,
-		string baseHost,
+		string federatorAttributeConsumerServiceUrl,
+		string spidProxyAttributeConsumerEndpoint,
 		bool skipTechnicalChecks)
 	{
 		var root = samlResponse.DocumentElement;
 		if (!root.HasAttribute("Destination") || string.IsNullOrWhiteSpace(root.GetAttribute("Destination")))
 			throw new SPIDValidationException("missing Destination");
 		var destValue = root.GetAttribute("Destination");
-		if (destValue != $"https://{baseHost}/proxy/assertionconsumer" && !skipTechnicalChecks)
+		if (destValue != spidProxyAttributeConsumerEndpoint && !skipTechnicalChecks)
 			throw new SPIDValidationException("different Destination");
 
-		var newDestination = attributeConsumerServiceUrl;
+		var newDestination = federatorAttributeConsumerServiceUrl;
 		root.SetAttribute("Destination", newDestination);
 
 		return samlResponse;

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/ConfigureForwardedHeadersOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/ConfigureForwardedHeadersOptions.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.HttpOverrides;
+using System.Net;
+
+namespace Microsoft.SPID.Proxy.Models.Options
+{
+	public class ConfigureForwardedHeadersOptions : IConfigureOptions<ForwardedHeadersOptions>
+	{
+		private readonly IConfiguration _configuration;
+		public ConfigureForwardedHeadersOptions(IConfiguration config)
+		{
+			_configuration = config;
+		}
+
+		public void Configure(ForwardedHeadersOptions options)
+		{
+			var section = _configuration.GetSection("ForwardedHeaders");
+			section.Bind(options);
+
+			var knownProxies = section.GetValue<string>("KnownProxies")?.Split(',');
+			var knownNetworks = section.GetValue<string>("KnownNetworks")?.Split(',');
+
+			if (knownProxies?.Length > 0)
+			{
+				options.KnownProxies.Clear();
+				foreach (var ip in knownProxies)
+				{
+					options.KnownProxies.Add(IPAddress.Parse(ip));
+				}
+			}
+
+			if (knownNetworks?.Length > 0)
+			{
+				options.KnownNetworks.Clear();
+				foreach (var network in knownNetworks)
+				{
+					var networkSplit = network.Split('/');
+					var prefix = networkSplit[0];
+					var prefixLength = int.Parse(networkSplit[1]);
+
+					options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse(prefix), prefixLength));
+				}
+			}
+		}
+	}
+}

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/ConfigureForwardedHeadersOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/ConfigureForwardedHeadersOptions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.SPID.Proxy.Models.Options
 
 			var knownProxies = section.GetValue<string>("KnownProxies")?.Split(',');
 			var knownNetworks = section.GetValue<string>("KnownNetworks")?.Split(',');
+			var allowedHosts = section.GetValue<string>("AllowedHosts")?.Split(',');
 
 			if (knownProxies?.Length > 0)
 			{
@@ -39,6 +40,12 @@ namespace Microsoft.SPID.Proxy.Models.Options
 
 					options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse(prefix), prefixLength));
 				}
+			}
+
+			if(allowedHosts?.Length > 0)
+			{
+				options.AllowedHosts.Clear();
+				options.AllowedHosts = allowedHosts;
 			}
 		}
 	}

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
@@ -12,7 +12,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 if (string.Equals(builder.Configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"], "true", StringComparison.OrdinalIgnoreCase))
 {
-	ConfigureForwardedHeadersOptions();
+	builder.Services.AddTransient<IConfigureOptions<ForwardedHeadersOptions>, ConfigureForwardedHeadersOptions>();
 }
 
 // Add services to the container.
@@ -74,38 +74,3 @@ app.MapControllerRoute(
 	pattern: "{controller=Home}/{action=Index}/{id?}");
 app.MapRazorPages();
 app.Run();
-
-void ConfigureForwardedHeadersOptions()
-{
-
-	builder.Services.Configure<ForwardedHeadersOptions>(options =>
-	{
-		var section = builder.Configuration.GetSection("ForwardedHeaders");
-		section.Bind(options);
-
-		var knownProxies = section.GetValue<string>("KnownProxies")?.Split(',');
-		var knownNetworks = section.GetValue<string>("KnownNetworks")?.Split(',');
-
-		if (knownProxies?.Length > 0)
-		{
-			options.KnownProxies.Clear();
-			foreach (var ip in knownProxies)
-			{
-				options.KnownProxies.Add(IPAddress.Parse(ip));
-			}
-		}
-
-		if (knownNetworks?.Length > 0)
-		{
-			options.KnownNetworks.Clear();
-			foreach (var network in knownNetworks)
-			{
-				var networkSplit = network.Split('/');
-				var prefix = networkSplit[0];
-				var prefixLength = int.Parse(networkSplit[1]);
-
-				options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse(prefix), prefixLength));
-			}
-		}
-	});
-}

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SAMLService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SAMLService.cs
@@ -31,7 +31,7 @@ public class SAMLService : ISAMLService
 
     public string GetAttributeConsumerService()
     {
-        return $"https://{_httpContextAccessor.HttpContext.Request.Host}/proxy/assertionconsumer";
+        return $"{_httpContextAccessor.HttpContext.Request.Scheme}://{_httpContextAccessor.HttpContext.Request.Host}/proxy/assertionconsumer";
 
     }
 

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/XMLResponseCheckService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/XMLResponseCheckService.cs
@@ -9,15 +9,19 @@ public class XMLResponseCheckService : IXMLResponseCheckService
 {
     private static readonly string[] cieIssuers = new string[] { "https://idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO", "https://preproduzione.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO" };
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ISAMLService _samlService;
+
     private readonly SPIDOptions _spidOptions;
     private readonly FederatorOptions _federatorOptions;
 
     public XMLResponseCheckService(IHttpContextAccessor httpContextAccessor,
+        ISAMLService samlService,
         IOptions<SPIDOptions> spidOptions,
         IOptions<FederatorOptions> federatorOptions)
     {
         _httpContextAccessor = httpContextAccessor;
-        _spidOptions = spidOptions.Value;
+		_samlService = samlService;
+		_spidOptions = spidOptions.Value;
         _federatorOptions = federatorOptions.Value;
     }
 
@@ -174,7 +178,7 @@ public class XMLResponseCheckService : IXMLResponseCheckService
         if (recipient == null)
             return;
 
-        if (recipient != $"https://{_httpContextAccessor.HttpContext.Request.Host}/proxy/assertionconsumer")
+        if (recipient != _samlService.GetAttributeConsumerService())
             throw new SPIDValidationException("SubjectConfirmationData Recipient must be equal to AssertionConsumerServiceUrl");
 
         var inResponseTo = SubjectConfirmationData.Attributes["InResponseTo"];

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -159,6 +159,7 @@
 		"CacheAbsoluteExpirationInMins": 120
 	},
 	"ForwardedHeaders": {
+		//"AllowedHosts": [ "allowedhost1.com", "allowedhost2.com", "allowedhostN.com" ],
 		"ForwardedHeaders": "All"
 	}
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -159,7 +159,7 @@
 		"CacheAbsoluteExpirationInMins": 120
 	},
 	"ForwardedHeaders": {
-		//"AllowedHosts": [ "allowedhost1.com", "allowedhost2.com", "allowedhostN.com" ],
+		"AllowedHosts": "*",
 		"ForwardedHeaders": "All"
 	},
 	"SPIDProxyLogging": {

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -157,5 +157,8 @@
 			"sp-proxy.eid.gov.it/spproxy/idpit": "https://sp-proxy.eid.gov.it/spproxy/idpitmetadata"
 		},
 		"CacheAbsoluteExpirationInMins": 120
+	},
+	"ForwardedHeaders": {
+		"ForwardedHeaders": "All"
 	}
 }


### PR DESCRIPTION
Add support to reverse proxies leveraging the ForwardedHeadersMiddleware.
When the ASPNETCORE_FORWARDEDHEADERS_ENABLED env variable is set to true, the ForwardedHeadersOptions are overridden using the ForwardedHeaders configuration section.

Whenever we need a SPIDProxy endpoint url, we use the SAMLService to retrieve it since it uses the HttpContext Scheme and Host which are overridden by the ForwardedHeadersMiddleware.

Fixes #2 