### PR TITLE
Add option to log decoded SAMLResponse

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/LoggingEvents.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/LoggingEvents.cs
@@ -15,6 +15,8 @@ namespace Microsoft.SPID.Proxy.Models
 		public const int OUTGOING_SAML_REQUEST_CREATED = 5004;
 		public const int USER_LOGGED_IN = 5005;
 		public const int PROXY_INDEX_INVOKED = 5006;
+		public const int INCOMING_SAML_RESPONSE_DECODED = 5007;
+
 
 		//Errors
 		public const int ERROR_IDENTITYPROVIDER_EMPTY = 9000;

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/LoggingOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/LoggingOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.SPID.Proxy.Models.Options
+{
+    public class LoggingOptions
+    {
+		public bool LogDecodedSamlResponse { get; set; } = false;
+	}
+}

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
@@ -36,11 +36,14 @@ builder.Services.Configure<CertificateOptions>(options => builder.Configuration.
 builder.Services.Configure<CustomErrorOptions>(options => builder.Configuration.GetSection("customErrors").Bind(options));
 builder.Services.Configure<FederatorOptions>(options => builder.Configuration.GetSection("Federator").Bind(options));
 builder.Services.Configure<IDPMetadatasOptions>(options => builder.Configuration.GetSection("idpMetadatas").Bind(options));
-builder.Services.Configure<LogAccessOptions>(options => builder.Configuration.GetSection("LogAccess").Bind(options));
-builder.Services.Configure<LogAccessOptions>(options => options.FieldsToLog = builder.Configuration.GetValue<string>("LogAccess:FieldsToLog").Split(",").ToList());
+builder.Services.Configure<LogAccessOptions>(options => {
+	builder.Configuration.GetSection("SPIDProxyLogging:LogAccess").Bind(options);
+	options.FieldsToLog = builder.Configuration.GetValue<string>("SPIDProxyLogging:LogAccess:FieldsToLog").Split(",").ToList();
+});
 builder.Services.Configure<SPIDOptions>(options => builder.Configuration.GetSection("spid").Bind(options));
 builder.Services.Configure<TechnicalChecksOptions>(options => builder.Configuration.GetSection("TechnicalChecks").Bind(options));
 builder.Services.Configure<EventLogSettings>(options => builder.Configuration.GetSection("Logging:EventLog:Settings").Bind(options));
+builder.Services.Configure<LoggingOptions>(options => builder.Configuration.GetSection("SPIDProxyLogging").Bind(options));
 
 builder.Services
 	.AddMvc()

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -32,10 +32,6 @@
 	"webpages:Enabled": false,
 	"ClientValidationEnabled": true,
 	"UnobtrusiveJavaScriptEnabled": true,
-	"LogAccess": {
-		"Enabled": true,
-		"FieldsToLog": "fiscalNumber,email,name,familyName"
-	},
 	"Certificate": {
 		"CertName": "YourPfxName.pfx",
 		"CertPassword": "YourPfxPassword"
@@ -161,5 +157,12 @@
 			"sp-proxy.eid.gov.it/spproxy/idpit": "https://sp-proxy.eid.gov.it/spproxy/idpitmetadata"
 		},
 		"CacheAbsoluteExpirationInMins": 120
+	},
+	"SPIDProxyLogging": {
+		"LogDecodedSamlResponse": false,
+		"LogAccess": {
+			"Enabled": true,
+			"FieldsToLog": "fiscalNumber,email,name,familyName,spidCode"
+		}
 	}
 }


### PR DESCRIPTION
 - Add LoggingOptions class with LogDecodedSamlResponse prop (defaults to false)
 - Add SPIDProxyLogging section in appsettings.json
 - Move LogAccess section inside SPIDProxyLogging section
 - Change Configure<T> methods accordingly
 - Add INCOMING_SAML_RESPONSE_DECODED event

Fixes #9 