### PR TITLE
Add CIEEntityId

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/RequestSAMLAsXMLExtensions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/RequestSAMLAsXMLExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.SPID.Proxy.Models.Extensions;
 
 public static class RequestSAMLAsXMLExtensions
 {
-    public static XmlDocument ChangeIssuer(this XmlDocument samlRequest, string spidEntityId)
+    public static XmlDocument ChangeIssuer(this XmlDocument samlRequest, string newEntityId)
     {
 		XmlElement rootEl = samlRequest.DocumentElement;
 		XmlNodeList IssuerTags = rootEl.GetElementsByTagName("Issuer", "*");
@@ -22,9 +22,9 @@ public static class RequestSAMLAsXMLExtensions
 			FormatAttribute.Value = "urn:oasis:names:tc:SAML:2.0:nameid-format:entity";
 			IssuerTag.Attributes.Append(FormatAttribute);
 			XmlAttribute nameQualifier = samlRequest.CreateAttribute("NameQualifier");
-			nameQualifier.Value = spidEntityId;
+			nameQualifier.Value = newEntityId;
 			IssuerTag.Attributes.Append(nameQualifier);
-			IssuerTag.InnerText = spidEntityId;
+			IssuerTag.InnerText = newEntityId;
 		}
 
 		return samlRequest;

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/FederatorOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/FederatorOptions.cs
@@ -11,6 +11,7 @@ public class FederatorOptions
 {
     public string MetadataUrl { get; set; }
     public string SPIDEntityId { get; set; }
+    public string CIEEntityId { get; set; }
     public string EntityId { get; set; }
     public string FederatorAttributeConsumerServiceUrl { get; set; }
     public X509IncludeOption X509IncludeOption { get; set; } = X509IncludeOption.EndCertOnly;

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorRequestService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorRequestService.cs
@@ -87,7 +87,8 @@ public class FederatorRequestService : IFederatorRequestService
                 rootEl.SetAttribute("Destination", idenityProviderUrl);
                 rootEl.RemoveAttribute("Consent");
 
-                requestAsXml.ChangeIssuer(_federatorOptions.SPIDEntityId);
+				string entityId = federatorRequest.IsCIE() ? _federatorOptions.CIEEntityId : _federatorOptions.SPIDEntityId;
+				requestAsXml.ChangeIssuer(entityId);
             }
             return requestAsXml;
         }
@@ -140,7 +141,8 @@ public class FederatorRequestService : IFederatorRequestService
             rootEl.RemoveAttribute("Consent");
             rootEl.RemoveAttribute("IsPassive");
 
-            requestAsXml.ChangeIssuer(_federatorOptions.SPIDEntityId);
+            string entityId = federatorRequest.IsCIE() ? _federatorOptions.CIEEntityId : _federatorOptions.SPIDEntityId;
+            requestAsXml.ChangeIssuer(entityId);
 
             var spidL = _spidService.GetSPIDLValue(refererQueryString, relayQueryString, wctxQueryString);
             //If no RequestedAuthnContext is already present, add it

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorRequestService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorRequestService.cs
@@ -87,7 +87,7 @@ public class FederatorRequestService : IFederatorRequestService
                 rootEl.SetAttribute("Destination", idenityProviderUrl);
                 rootEl.RemoveAttribute("Consent");
 
-				string entityId = federatorRequest.IsCIE() ? _federatorOptions.CIEEntityId : _federatorOptions.SPIDEntityId;
+				string entityId = GetNewEntityId(federatorRequest);
 				requestAsXml.ChangeIssuer(entityId);
             }
             return requestAsXml;
@@ -140,8 +140,7 @@ public class FederatorRequestService : IFederatorRequestService
             rootEl.SetAttribute("Destination", idenityProviderUrl);
             rootEl.RemoveAttribute("Consent");
             rootEl.RemoveAttribute("IsPassive");
-
-            string entityId = federatorRequest.IsCIE() ? _federatorOptions.CIEEntityId : _federatorOptions.SPIDEntityId;
+            string entityId = GetNewEntityId(federatorRequest);
             requestAsXml.ChangeIssuer(entityId);
 
             var spidL = _spidService.GetSPIDLValue(refererQueryString, relayQueryString, wctxQueryString);
@@ -182,5 +181,10 @@ public class FederatorRequestService : IFederatorRequestService
             _logger.LogError(ex,"Something went wrong transforming the incoming SAML Xml into the desired outgoing SAML Xml");
             throw;
         }
+    }
+
+    private string GetNewEntityId(FederatorRequest federatorRequest)
+    {
+        return federatorRequest.IsCIE() ? _federatorOptions.CIEEntityId : _federatorOptions.SPIDEntityId;
     }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/XMLResponseCheckService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/XMLResponseCheckService.cs
@@ -160,7 +160,7 @@ public class XMLResponseCheckService : IXMLResponseCheckService
         if (audience == null || string.IsNullOrWhiteSpace(audience.InnerText))
             throw new SPIDValidationException("Audience not specified");
 
-        if (audience.InnerText != _federatorOptions.SPIDEntityId)
+        if (audience.InnerText != _federatorOptions.SPIDEntityId && audience.InnerText != _federatorOptions.CIEEntityId)
             throw new SPIDValidationException("Audience is different from SP EntityID");
     }
 

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -40,7 +40,8 @@
     },
     "Federator": {
         "MetadataUrl": "https://your.adfs.metadata.url/FederationMetadata/2007-06/FederationMetadata.xml",
-        "SPIDEntityId": "https://your.adfs.url/adfs/services/trust",
+        "SPIDEntityId": "SPIDhttps://your.adfs.url/adfs/services/trust",
+        "CIEEntityId": "CIEhttps://your.adfs.url/adfs/services/trust",
         "EntityId": "https://your.adfs.url/adfs/services/trust",
         "FederatorAttributeConsumerServiceUrl": "https://adfs.url/adfs/ls",
         "X509IncludeOption": "EndCertOnly"


### PR DESCRIPTION
If the SAMLRequest destination is a CIE environment, then you can use a specific entityId via CIEEntityId setting. This is useful in the case you have different EntityId set in CIE and SPID metadatas.