### PR TITLE
Refactor CIE and SPID SpidLevel, fix retrieval of Referer queryString

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/FederatorRequestExtensions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/FederatorRequestExtensions.cs
@@ -25,21 +25,35 @@ public static class FederatorRequestExtensions
     }
 
     public static int GetAttributeConsumingService(this FederatorRequest federatorRequest,
-        int cieAttributeConsumerServiceValue,
-        int eidasAttributeConsumerServiceValue,
-        int attributeConsumerService)
+        int cieAttributeConsumingServiceValue,
+        int eidasAttributeConsumingServiceValue,
+        int spidAttributeConsumingService)
     {
         if (federatorRequest.IsCIE())
         {
-            return cieAttributeConsumerServiceValue;
+            return cieAttributeConsumingServiceValue;
         }
         else if (federatorRequest.IsEIDAS())
         {
-            return eidasAttributeConsumerServiceValue;
+            return eidasAttributeConsumingServiceValue;
         }
         else
         {
-            return attributeConsumerService;
+            return spidAttributeConsumingService;
+        }
+    }
+
+    public static int GetSPIDLevel(this FederatorRequest federatorRequest,
+        int cieSpidLevel,
+        int spidSpidLevel)
+    {
+        if (federatorRequest.IsCIE())
+        {
+            return cieSpidLevel;
+        }
+        else
+        {
+            return spidSpidLevel;
         }
     }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/RequestSAMLAsXMLExtensions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/RequestSAMLAsXMLExtensions.cs
@@ -104,19 +104,19 @@ public static class RequestSAMLAsXMLExtensions
 		return samlRequest;
 	}
 
-	public static XmlDocument SetComparison(this XmlDocument samlRequest)
+	public static XmlDocument SetComparison(this XmlDocument samlRequest, string comparisonValue)
     {
 		var RequestedAuthnContext = samlRequest.GetElementsByTagName("RequestedAuthnContext", "*")[0];
 		var comparison = RequestedAuthnContext.Attributes["Comparison"];
 		if (comparison == null)
 		{
 			XmlAttribute NewComparison = samlRequest.CreateAttribute("Comparison");
-			NewComparison.Value = "minimum";
+			NewComparison.Value = comparisonValue;
 			RequestedAuthnContext.Attributes.Append(NewComparison);
 		}
 		else
 		{
-			comparison.Value = "minimum";
+			comparison.Value = comparisonValue;
 		}
 
 		return samlRequest;

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/CIEOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/CIEOptions.cs
@@ -1,0 +1,13 @@
+﻿/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace Microsoft.SPID.Proxy.Models.Options
+{
+	public class CIEOptions
+	{
+        public int DefaultSPIDL  { get; set; }
+        public string DefaultComparison { get; set; }
+    }
+}

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/SPIDOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/SPIDOptions.cs
@@ -14,4 +14,7 @@ public class SPIDOptions
     public string PurposeName { get; set; }
     public string SpidLevelQueryStringParamName { get; set; }
     public int AssertionIssueInstantToleranceMins { get; set; }
+    public string DefaultComparison{ get; set; }
+
+    public string ComparisonQueryStringParamName { get; set; }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
@@ -49,6 +49,7 @@ builder.Services.Configure<LogAccessOptions>(options => {
 	options.FieldsToLog = builder.Configuration.GetValue<string>("SPIDProxyLogging:LogAccess:FieldsToLog").Split(",").ToList();
 });
 builder.Services.Configure<SPIDOptions>(options => builder.Configuration.GetSection("spid").Bind(options));
+builder.Services.Configure<CIEOptions>(options => builder.Configuration.GetSection("cie").Bind(options));
 builder.Services.Configure<TechnicalChecksOptions>(options => builder.Configuration.GetSection("TechnicalChecks").Bind(options));
 builder.Services.Configure<EventLogSettings>(options => builder.Configuration.GetSection("Logging:EventLog:Settings").Bind(options));
 builder.Services.Configure<LoggingOptions>(options => builder.Configuration.GetSection("SPIDProxyLogging").Bind(options));

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/ISPIDService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/ISPIDService.cs
@@ -9,10 +9,12 @@ namespace Microsoft.SPID.Proxy.Services;
 
 public interface ISPIDService
 {
-    int GetACSValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
-    int GetSPIDLValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
-    string GetPurposeValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
+    int GetAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
+	int GetSPIDLValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString, bool isCie);
+	string GetComparisonValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString, bool isCie);
+	string GetPurposeValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
     bool IsSpidLValid(NameValueCollection queryStringCollection, string origin = "");
     bool IsPurposeValid(NameValueCollection queryStringCollection, string origin = "");
     bool IsACSValid(NameValueCollection queryStringCollection, string origin = "");
+    bool IsComparisonValid(NameValueCollection queryStringCollection, string origin = "");
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SAMLService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SAMLService.cs
@@ -37,7 +37,8 @@ public class SAMLService : ISAMLService
 
     public NameValueCollection GetRefererQueryString()
     {
-        return HttpUtility.ParseQueryString(_httpContextAccessor.HttpContext.Request.Headers["Referer"]);
+        Uri refererUri = new Uri(_httpContextAccessor.HttpContext.Request.Headers["Referer"]);
+        return HttpUtility.ParseQueryString(refererUri.Query);
     }
 
     public NameValueCollection GetRelayStateQueryString(NameValueCollection refererQueryString)

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
@@ -9,172 +9,222 @@ namespace Microsoft.SPID.Proxy.Services.Implementations;
 
 public class SPIDService : ISPIDService
 {
-    private readonly ILogger _logger;
-    private readonly SPIDOptions _spidOptions;
-    private readonly AttributeConsumingServiceOptions _attributeConsumingServiceOptions;
-    public SPIDService(ILogger<SPIDService> logger, 
-        IOptions<SPIDOptions> spidOptions, 
-        IOptions<AttributeConsumingServiceOptions> attributeConsumingServiceOptions)
-    {
-        _logger = logger;
-        _spidOptions = spidOptions.Value;
-        _attributeConsumingServiceOptions = attributeConsumingServiceOptions.Value;
-    }
+	private readonly ILogger _logger;
+	private readonly CIEOptions _cieOptions;
+	private readonly SPIDOptions _spidOptions;
+	private readonly AttributeConsumingServiceOptions _attributeConsumingServiceOptions;
 
-    public bool IsSpidLValid(NameValueCollection queryStringCollection, string origin = "")
-    {
+	public SPIDService(ILogger<SPIDService> logger,
+		IOptions<SPIDOptions> spidOptions,
+		IOptions<AttributeConsumingServiceOptions> attributeConsumingServiceOptions,
+		IOptions<CIEOptions> cieOptions)
+	{
+		_logger = logger;
+		_cieOptions = cieOptions.Value;
+		_spidOptions = spidOptions.Value;
+		_attributeConsumingServiceOptions = attributeConsumingServiceOptions.Value;
+	}
 
-        if (queryStringCollection == null)
-        {
-            _logger.LogDebug("Checking {SpidLevelQueryStringParamName} in {origin}: queryString is null", _spidOptions.SpidLevelQueryStringParamName, origin);
-            return false;
-        }
+	public bool IsSpidLValid(NameValueCollection queryStringCollection, string origin = "")
+	{
 
-        if (string.IsNullOrWhiteSpace(queryStringCollection[_spidOptions.SpidLevelQueryStringParamName]))
-        {
-            _logger.LogDebug("Checking {SpidLevelQueryStringParamName} in {origin}: {SpidLevelQueryStringParamName} key not present", _spidOptions.SpidLevelQueryStringParamName, origin, _spidOptions.SpidLevelQueryStringParamName);
-            return false;
-        }
+		if (queryStringCollection == null)
+		{
+			_logger.LogDebug("Checking {SpidLevelQueryStringParamName} in {origin}: queryString is null", _spidOptions.SpidLevelQueryStringParamName, origin);
+			return false;
+		}
 
-        if (!_spidOptions.ValidSPIDL.Contains(int.Parse(queryStringCollection[_spidOptions.SpidLevelQueryStringParamName])))
-        {
-            _logger.LogDebug("Checking {SpidLevelQueryStringParamName} in {origin}: {SpidLevelQueryStringParamName} value not valid. Found: {foundSpidLevelQueryStringParamName}, Expecting: [{expectedSpidLevelQueryStringParamName}]", 
-                _spidOptions.SpidLevelQueryStringParamName, origin, _spidOptions.SpidLevelQueryStringParamName, queryStringCollection[_spidOptions.SpidLevelQueryStringParamName], string.Join(",", _spidOptions.ValidSPIDL));
-            return false;
-        }
+		if (string.IsNullOrWhiteSpace(queryStringCollection[_spidOptions.SpidLevelQueryStringParamName]))
+		{
+			_logger.LogDebug("Checking {SpidLevelQueryStringParamName} in {origin}: {SpidLevelQueryStringParamName} key not present", _spidOptions.SpidLevelQueryStringParamName, origin, _spidOptions.SpidLevelQueryStringParamName);
+			return false;
+		}
 
-        return true;
-    }
+		if (!_spidOptions.ValidSPIDL.Contains(int.Parse(queryStringCollection[_spidOptions.SpidLevelQueryStringParamName])))
+		{
+			_logger.LogDebug("Checking {SpidLevelQueryStringParamName} in {origin}: {SpidLevelQueryStringParamName} value not valid. Found: {foundSpidLevelQueryStringParamName}, Expecting: [{expectedSpidLevelQueryStringParamName}]",
+				_spidOptions.SpidLevelQueryStringParamName, origin, _spidOptions.SpidLevelQueryStringParamName, queryStringCollection[_spidOptions.SpidLevelQueryStringParamName], string.Join(",", _spidOptions.ValidSPIDL));
+			return false;
+		}
 
-    public bool IsPurposeValid(NameValueCollection queryStringCollection, string origin = "")
-    {
-        if (queryStringCollection == null)
-        {
-            _logger.LogDebug("Checking {PurposeName} in {origin}: queryString is null", _spidOptions.PurposeName, origin);
-            return false;
-        }
+		return true;
+	}
 
-        if (string.IsNullOrWhiteSpace(queryStringCollection[_spidOptions.PurposeName]))
-        {
-            _logger.LogDebug("Checking {PurposeName} in {origin}: {PurposeName} key not present", _spidOptions.PurposeName, origin, _spidOptions.PurposeName);
-            return false;
-        }
+	public bool IsPurposeValid(NameValueCollection queryStringCollection, string origin = "")
+	{
+		if (queryStringCollection == null)
+		{
+			_logger.LogDebug("Checking {PurposeName} in {origin}: queryString is null", _spidOptions.PurposeName, origin);
+			return false;
+		}
 
-        if (!_spidOptions.ValidSPIDPurposeExtension.Contains(queryStringCollection[_spidOptions.PurposeName]))
-        {
-            _logger.LogDebug("Checking {PurposeName} in {origin}: {PurposeName} value not valid. Found: {foundPurposeName}, Expecting: [{expectedPurposeName}]",
-                _spidOptions.PurposeName, origin, _spidOptions.PurposeName, queryStringCollection[_spidOptions.PurposeName], string.Join(",", _spidOptions.ValidSPIDPurposeExtension));
-            return false;
-        }
+		if (string.IsNullOrWhiteSpace(queryStringCollection[_spidOptions.PurposeName]))
+		{
+			_logger.LogDebug("Checking {PurposeName} in {origin}: {PurposeName} key not present", _spidOptions.PurposeName, origin, _spidOptions.PurposeName);
+			return false;
+		}
 
-        return true;
-    }
+		if (!_spidOptions.ValidSPIDPurposeExtension.Contains(queryStringCollection[_spidOptions.PurposeName]))
+		{
+			_logger.LogDebug("Checking {PurposeName} in {origin}: {PurposeName} value not valid. Found: {foundPurposeName}, Expecting: [{expectedPurposeName}]",
+				_spidOptions.PurposeName, origin, _spidOptions.PurposeName, queryStringCollection[_spidOptions.PurposeName], string.Join(",", _spidOptions.ValidSPIDPurposeExtension));
+			return false;
+		}
 
-    public bool IsACSValid(NameValueCollection queryStringCollection, string origin = "")
-    {
+		return true;
+	}
 
-        if (queryStringCollection == null)
-        {
-            _logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: queryString is null", _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin);
-            return false;
-        }
+	public bool IsACSValid(NameValueCollection queryStringCollection, string origin = "")
+	{
 
-        if (string.IsNullOrWhiteSpace(queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]))
-        {
-            _logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: {AttrConsServIndexQueryStringParamName} key not present",
-                _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin, _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName);
-            return false;
-        }
+		if (queryStringCollection == null)
+		{
+			_logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: queryString is null", _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin);
+			return false;
+		}
 
-        if (!_attributeConsumingServiceOptions.ValidACS.Contains(queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]))
-        {
-            _logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: {AttrConsServIndexQueryStringParamName} value not valid. Found: {foundAttrConsServIndexQueryStringParamName]}, Expecting one of: [{expectedAttrConsServIndexQueryStringParamName}]",
-                _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin, _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName], _attributeConsumingServiceOptions.ValidACS);
-            return false;
-        }
+		if (string.IsNullOrWhiteSpace(queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]))
+		{
+			_logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: {AttrConsServIndexQueryStringParamName} key not present",
+				_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin, _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName);
+			return false;
+		}
 
-        return true;
-    }
+		if (!_attributeConsumingServiceOptions.ValidACS.Contains(queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]))
+		{
+			_logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: {AttrConsServIndexQueryStringParamName} value not valid. Found: {foundAttrConsServIndexQueryStringParamName]}, Expecting one of: [{expectedAttrConsServIndexQueryStringParamName}]",
+				_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin, _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName], _attributeConsumingServiceOptions.ValidACS);
+			return false;
+		}
 
-    public int GetACSValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
-    {
-        var ACSValue = _attributeConsumingServiceOptions.AttributeConsumingServiceDefaultValue;
+		return true;
+	}
+	public bool IsComparisonValid(NameValueCollection queryStringCollection, string origin = "")
+	{
 
-        //check for ACS in referer first, then relaystate, then wctx. If none is found, use default
-        if (IsACSValid(refererQueryString, "REFERER"))
-        {
-            _logger.LogDebug("Using AttributeConsumingServiceIndex from Referer: {acsValue}", refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-            ACSValue = int.Parse(refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-        }
-        else if (IsACSValid(relayQueryString, "RELAYSTATE"))
-        {
-            _logger.LogDebug("Using AttributeConsumingServiceIndex from RelayState: {acsValue}", relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-            ACSValue = int.Parse(relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-        }
-        else if (IsACSValid(wctxQueryString, "WCTX"))
-        {
-            _logger.LogDebug("Using AttributeConsumingServiceIndex from WCTX: {acsValue}", wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-            ACSValue = int.Parse(wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-        }
-        else
-        {
-            _logger.LogDebug("Using Default AttributeConsumingServiceIndex: {acsValue}", ACSValue);
-        }
+		if (queryStringCollection == null)
+		{
+			_logger.LogDebug("Checking {ComparisonQueryStringParamName} in {origin}: queryString is null", _spidOptions.ComparisonQueryStringParamName, origin);
+			return false;
+		}
 
-        return ACSValue;
-    }
+		if (string.IsNullOrWhiteSpace(queryStringCollection[_spidOptions.ComparisonQueryStringParamName]))
+		{
+			_logger.LogDebug("Checking {ComparisonQueryStringParamName} in {origin}: {ComparisonQueryStringParamName} key not present",
+				_spidOptions.ComparisonQueryStringParamName, origin, _spidOptions.ComparisonQueryStringParamName);
+			return false;
+		}
 
-    public int GetSPIDLValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
-    {
-        var spidL = _spidOptions.DefaultSPIDL;
+		return true;
+	}
 
-        if (IsSpidLValid(refererQueryString, "REFERER"))
-        {
-            _logger.LogDebug("Using spidL from Referer: {spidLValue}", refererQueryString[_spidOptions.SpidLevelQueryStringParamName]);
-            spidL = int.Parse(refererQueryString[_spidOptions.SpidLevelQueryStringParamName]);
-        }
-        else if (IsSpidLValid(relayQueryString, "RELAYSTATE"))
-        {
-            _logger.LogDebug("Using spidL from RelayState: {spidLValue}", relayQueryString[_spidOptions.SpidLevelQueryStringParamName]);
-            spidL = int.Parse(relayQueryString[_spidOptions.SpidLevelQueryStringParamName]);
-        }
-        else if (IsSpidLValid(wctxQueryString, "WCTX"))
-        {
-            _logger.LogDebug("Using spidL from WCTX: {spidLValue}", wctxQueryString[_spidOptions.SpidLevelQueryStringParamName]);
-            spidL = int.Parse(wctxQueryString[_spidOptions.SpidLevelQueryStringParamName]);
-        }
-        else
-        {
-            _logger.LogDebug("Using Default spidL: {spidLValue}", spidL);
-        }
+	public int GetAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
+	{
+		var ACSValue = _attributeConsumingServiceOptions.AttributeConsumingServiceDefaultValue;
 
-        return spidL;
-    }
+		//check for ACS in referer first, then relaystate, then wctx. If none is found, use default
+		if (IsACSValid(refererQueryString, "REFERER"))
+		{
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from Referer: {acsValue}", refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+			ACSValue = int.Parse(refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+		}
+		else if (IsACSValid(relayQueryString, "RELAYSTATE"))
+		{
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from RelayState: {acsValue}", relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+			ACSValue = int.Parse(relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+		}
+		else if (IsACSValid(wctxQueryString, "WCTX"))
+		{
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from WCTX: {acsValue}", wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+			ACSValue = int.Parse(wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+		}
+		else
+		{
+			_logger.LogDebug("Using Default AttributeConsumingServiceIndex: {acsValue}", ACSValue);
+		}
 
-    public string GetPurposeValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
-    {
-        string purposeValue = string.Empty;
+		return ACSValue;
+	}
 
-        if (IsPurposeValid(refererQueryString, "REFERER"))
-        {
-            _logger.LogDebug("Using Purpose from Referer: {purposeValue}", refererQueryString[_spidOptions.PurposeName]);
-            purposeValue = refererQueryString[_spidOptions.PurposeName];
-        }
-        else if (IsPurposeValid(relayQueryString, "RELAYSTATE"))
-        {
-            _logger.LogDebug("Using Purpose from RelayState: {purposeValue}", relayQueryString[_spidOptions.PurposeName]);
-            purposeValue = relayQueryString[_spidOptions.PurposeName];
-        }
-        else if (IsPurposeValid(wctxQueryString, "WCTX"))
-        {
-            _logger.LogDebug("Using Purpose from WCTX: {purposeValue}", wctxQueryString[_spidOptions.PurposeName]);
-            purposeValue = wctxQueryString[_spidOptions.PurposeName];
-        }
-        else
-        {
-            _logger.LogDebug("Not adding Purpose extension to the SAMl request");
-        }
+	public int GetSPIDLValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString, bool isCie)
+	{
+		var spidL = isCie ? _cieOptions.DefaultSPIDL : _spidOptions.DefaultSPIDL;
 
-        return purposeValue;
-    }
+		if (IsSpidLValid(refererQueryString, "REFERER"))
+		{
+			_logger.LogDebug("Using spidL from Referer: {spidLValue}", refererQueryString[_spidOptions.SpidLevelQueryStringParamName]);
+			spidL = int.Parse(refererQueryString[_spidOptions.SpidLevelQueryStringParamName]);
+		}
+		else if (IsSpidLValid(relayQueryString, "RELAYSTATE"))
+		{
+			_logger.LogDebug("Using spidL from RelayState: {spidLValue}", relayQueryString[_spidOptions.SpidLevelQueryStringParamName]);
+			spidL = int.Parse(relayQueryString[_spidOptions.SpidLevelQueryStringParamName]);
+		}
+		else if (IsSpidLValid(wctxQueryString, "WCTX"))
+		{
+			_logger.LogDebug("Using spidL from WCTX: {spidLValue}", wctxQueryString[_spidOptions.SpidLevelQueryStringParamName]);
+			spidL = int.Parse(wctxQueryString[_spidOptions.SpidLevelQueryStringParamName]);
+		}
+		else
+		{
+			_logger.LogDebug("Using Default spidL: {spidLValue}, isCIE: {isCie}", spidL, isCie);
+		}
+
+		return spidL;
+	}
+
+	public string GetPurposeValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
+	{
+		string purposeValue = string.Empty;
+
+		if (IsPurposeValid(refererQueryString, "REFERER"))
+		{
+			_logger.LogDebug("Using Purpose from Referer: {purposeValue}", refererQueryString[_spidOptions.PurposeName]);
+			purposeValue = refererQueryString[_spidOptions.PurposeName];
+		}
+		else if (IsPurposeValid(relayQueryString, "RELAYSTATE"))
+		{
+			_logger.LogDebug("Using Purpose from RelayState: {purposeValue}", relayQueryString[_spidOptions.PurposeName]);
+			purposeValue = relayQueryString[_spidOptions.PurposeName];
+		}
+		else if (IsPurposeValid(wctxQueryString, "WCTX"))
+		{
+			_logger.LogDebug("Using Purpose from WCTX: {purposeValue}", wctxQueryString[_spidOptions.PurposeName]);
+			purposeValue = wctxQueryString[_spidOptions.PurposeName];
+		}
+		else
+		{
+			_logger.LogDebug("Not adding Purpose extension to the SAMl request");
+		}
+
+		return purposeValue;
+	}
+
+	public string GetComparisonValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString, bool isCie)
+	{
+		var comparisonValue = isCie ? _cieOptions.DefaultComparison : _spidOptions.DefaultComparison;
+
+		//check for comparison in referer first, then relaystate, then wctx. If none is found, use default
+		if (IsComparisonValid(refererQueryString, "REFERER"))
+		{
+			_logger.LogDebug("Using Comparison from Referer: {comparisonValue}", refererQueryString[_spidOptions.ComparisonQueryStringParamName]);
+			comparisonValue = refererQueryString[_spidOptions.ComparisonQueryStringParamName];
+		}
+		else if (IsComparisonValid(relayQueryString, "RELAYSTATE"))
+		{
+			_logger.LogDebug("Using Comparison from RelayState: {comparisonValue}", relayQueryString[_spidOptions.ComparisonQueryStringParamName]);
+			comparisonValue = relayQueryString[_spidOptions.ComparisonQueryStringParamName];
+		}
+		else if (IsComparisonValid(wctxQueryString, "WCTX"))
+		{
+			_logger.LogDebug("Using Comparison from WCTX: {comparisonValue}", wctxQueryString[_spidOptions.ComparisonQueryStringParamName]);
+			comparisonValue = wctxQueryString[_spidOptions.ComparisonQueryStringParamName];
+		}
+		else
+		{
+			_logger.LogDebug("Using Default Comparison: {comparisonValue}, isCie: {isCie}", comparisonValue, isCie);
+		}
+
+		return comparisonValue;
+	}
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -47,7 +47,8 @@
         "X509IncludeOption": "EndCertOnly"
     },
     "spid": {
-        "DefaultSPIDL": 1,
+        "DefaultSPIDL": 2,
+        "DefaultComparison": "minimum",
         "ValidSPIDL": [
             1,
             2,
@@ -63,7 +64,12 @@
         ],
         "PurposeName": "Purpose",
         "SpidLevelQueryStringParamName": "spidL",
+        "ComparisonQueryStringParamName": "comparison",
         "AssertionIssueInstantToleranceMins": 15
+    },
+    "cie": {
+        "DefaultSPIDL": 3,
+        "DefaultComparison": "minimum"
     },
     "attributeConsumingService": {
         "AttributeConsumingServiceDefaultValue": 0,


### PR DESCRIPTION
- Comparison is now configurable for both CIE and SPID
- Comparison can be customized via Referer, RelayState, wctx, just like SpidLevel and AttrConsumingService index
- CIE now has separate configuration for SpidLevel

Closes #51 