### PR TITLE
Fix wctx and relayState queryString retrieval

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SAMLService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SAMLService.cs
@@ -50,7 +50,7 @@ public class SAMLService : ISAMLService
             var questMarkIndex = relayState.IndexOf("?");
 
             relayQueryString = questMarkIndex > -1 ?
-                HttpUtility.ParseQueryString(relayState.Substring(questMarkIndex)) : null;
+                HttpUtility.ParseQueryString(relayState.Substring(questMarkIndex)) : HttpUtility.ParseQueryString(relayState);
         }
 
         return relayQueryString;
@@ -87,7 +87,8 @@ public class SAMLService : ISAMLService
         {
             var questMarkIndex = wctx.IndexOf("?");
 
-            wctxQueryString = questMarkIndex > -1 ? HttpUtility.ParseQueryString(wctx.Substring(questMarkIndex)) : null;
+            wctxQueryString = questMarkIndex > -1 ? HttpUtility.ParseQueryString(wctx.Substring(questMarkIndex)) 
+                : HttpUtility.ParseQueryString(wctx);
 
         }
 


### PR DESCRIPTION
If the RelayState or wctx doesn't contain a '?', try to parse the whole RelayState/wctx as a querystring