### PR TITLE
Add a configurable alteration on the SAMLResponse to change the xsi:type for the claim dateOfBirth

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Controllers/ProxyController.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Controllers/ProxyController.cs
@@ -177,6 +177,8 @@ public class ProxyController : Controller
 					.AlterSubjectConfirmation(_federatorOptions.FederatorAttributeConsumerServiceUrl)
 					.RemoveNameQualifierIfFormatEntity();
 
+				_federatorResponseService.ApplyOptionalResponseAlteration(responseXml);
+
 				await _federatorResponseService.SignAssertionAsync(responseXml);
 				_logger.LogDebug("Assertions Signed");
 

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/LoggingEvents.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/LoggingEvents.cs
@@ -16,6 +16,8 @@ namespace Microsoft.SPID.Proxy.Models
 		public const int USER_LOGGED_IN = 5005;
 		public const int PROXY_INDEX_INVOKED = 5006;
 		public const int INCOMING_SAML_RESPONSE_DECODED = 5007;
+		public const int ALTERED_DATEOFBIRTH_TYPE = 5008;
+
 
 
 		//Errors

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/OptionalResponseAlterationOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/OptionalResponseAlterationOptions.cs
@@ -1,0 +1,13 @@
+﻿/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace Microsoft.SPID.Proxy.Models.Options
+{
+	public class OptionalResponseAlterationOptions
+	{
+		public bool AlterDateOfBirth { get; set; }
+        public string DateOfBirthFormat { get; set; }
+    }
+}

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/OptionalResponseAlterationOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/OptionalResponseAlterationOptions.cs
@@ -8,6 +8,6 @@ namespace Microsoft.SPID.Proxy.Models.Options
 	public class OptionalResponseAlterationOptions
 	{
 		public bool AlterDateOfBirth { get; set; }
-        public string DateOfBirthFormat { get; set; }
+		public string DateOfBirthFormat { get; set; } = "xs:date";
     }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
@@ -53,6 +53,7 @@ builder.Services.Configure<CIEOptions>(options => builder.Configuration.GetSecti
 builder.Services.Configure<TechnicalChecksOptions>(options => builder.Configuration.GetSection("TechnicalChecks").Bind(options));
 builder.Services.Configure<EventLogSettings>(options => builder.Configuration.GetSection("Logging:EventLog:Settings").Bind(options));
 builder.Services.Configure<LoggingOptions>(options => builder.Configuration.GetSection("SPIDProxyLogging").Bind(options));
+builder.Services.Configure<OptionalResponseAlterationOptions>(builder.Configuration.GetSection("OptionalResponseAlteration"));
 
 builder.Services
 	.AddMvc()

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/IFederatorResponseService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/IFederatorResponseService.cs
@@ -22,4 +22,6 @@ public interface IFederatorResponseService
     string GetUserFriendlyMessage(string statusMessageText);
 
     Task SignAssertionAsync(XmlDocument doc, string assertionDigestMethod = SignedXml.XmlDsigSHA256Url);
+
+    void ApplyOptionalResponseAlteration(XmlDocument doc);
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorResponseService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorResponseService.cs
@@ -4,243 +4,291 @@
  *--------------------------------------------------------------------------------------------*/
 
 using Microsoft.AspNetCore.Html;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.SPID.Proxy.Models.Options;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.SPID.Proxy.Services.Implementations;
 
 public class FederatorResponseService : IFederatorResponseService
 {
-    private readonly IXMLResponseCheckService _xmlResponseCheckService;
-    private readonly ICertificateService _certificateService;
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly IDistributedCache _cache;
-    private readonly ILogger _logger;
-    private readonly IDPMetadatasOptions _idpMetadatasOptions;
-    private readonly CustomErrorOptions _customErrorOptions;
-    private readonly TechnicalChecksOptions _technicalChecksOptions;
-    private readonly FederatorOptions _federatorOptions;
+	private readonly IXMLResponseCheckService _xmlResponseCheckService;
+	private readonly ICertificateService _certificateService;
+	private readonly IHttpClientFactory _httpClientFactory;
+	private readonly IDistributedCache _cache;
+	private readonly ILogger _logger;
+	private readonly IDPMetadatasOptions _idpMetadatasOptions;
+	private readonly CustomErrorOptions _customErrorOptions;
+	private readonly TechnicalChecksOptions _technicalChecksOptions;
+	private readonly FederatorOptions _federatorOptions;
+	private readonly OptionalResponseAlterationOptions _optionalResponseAlterationOptions;
 
-    public FederatorResponseService(IXMLResponseCheckService xmlResponseCheckService,
-        ICertificateService certificateService,
-        IHttpClientFactory httpClientFactory,
-        IDistributedCache cache,
-        ILogger<FederatorResponseService> logger,
-        IOptions<CustomErrorOptions> customErrorOptions,
-        IOptions<IDPMetadatasOptions> idpMetadataOptions,
-        IOptions<TechnicalChecksOptions> technicalChecksOptions,
-        IOptions<FederatorOptions> federatorOptions)
-    {
-        _xmlResponseCheckService = xmlResponseCheckService;
-        _certificateService = certificateService;
-        _httpClientFactory = httpClientFactory;
-        _cache = cache;
-        _logger = logger;
-        _customErrorOptions = customErrorOptions.Value;
-        _idpMetadatasOptions = idpMetadataOptions.Value;
-        _technicalChecksOptions = technicalChecksOptions.Value;
-        _federatorOptions = federatorOptions.Value;
-    }
+	public FederatorResponseService(IXMLResponseCheckService xmlResponseCheckService,
+		ICertificateService certificateService,
+		IHttpClientFactory httpClientFactory,
+		IDistributedCache cache,
+		ILogger<FederatorResponseService> logger,
+		IOptions<CustomErrorOptions> customErrorOptions,
+		IOptions<IDPMetadatasOptions> idpMetadataOptions,
+		IOptions<TechnicalChecksOptions> technicalChecksOptions,
+		IOptions<FederatorOptions> federatorOptions,
+		IOptions<OptionalResponseAlterationOptions> optionalResponseAlterationOptions)
+	{
+		_xmlResponseCheckService = xmlResponseCheckService;
+		_certificateService = certificateService;
+		_httpClientFactory = httpClientFactory;
+		_cache = cache;
+		_logger = logger;
+		_customErrorOptions = customErrorOptions.Value;
+		_idpMetadatasOptions = idpMetadataOptions.Value;
+		_technicalChecksOptions = technicalChecksOptions.Value;
+		_federatorOptions = federatorOptions.Value;
+		_optionalResponseAlterationOptions = optionalResponseAlterationOptions.Value;
+	}
 
-    public FederatorResponse GetFederatorResponse(XmlDocument samlResponse, string relayState)
-    {
-        return new(samlResponse.EncodeSamlResponse(), relayState, _federatorOptions.FederatorAttributeConsumerServiceUrl);
-    }
+	public FederatorResponse GetFederatorResponse(XmlDocument samlResponse, string relayState)
+	{
+		return new(samlResponse.EncodeSamlResponse(), relayState, _federatorOptions.FederatorAttributeConsumerServiceUrl);
+	}
 
-    public void RunTechnicalChecks(XmlDocument responseXml)
-    {
-        if (!_technicalChecksOptions.SkipTechnicalChecks)
-        {
-            _xmlResponseCheckService.CheckResponseVersion(responseXml);
-            _logger.LogTrace("Checked Response Version");
+	public void RunTechnicalChecks(XmlDocument responseXml)
+	{
+		if (!_technicalChecksOptions.SkipTechnicalChecks)
+		{
+			_xmlResponseCheckService.CheckResponseVersion(responseXml);
+			_logger.LogTrace("Checked Response Version");
 
-            _xmlResponseCheckService.CheckResponseIssueInstant(responseXml);
-            _logger.LogTrace("Checked Response IssueInstant");
+			_xmlResponseCheckService.CheckResponseIssueInstant(responseXml);
+			_logger.LogTrace("Checked Response IssueInstant");
 
-            _xmlResponseCheckService.CheckResponseInResponseTo(responseXml);
-            _logger.LogTrace("Checked Response InResponseTo");
+			_xmlResponseCheckService.CheckResponseInResponseTo(responseXml);
+			_logger.LogTrace("Checked Response InResponseTo");
 
-            _xmlResponseCheckService.CheckAuthnContextClassRef(responseXml);
-            _logger.LogTrace("Checked AuthnContextClassRef");
+			_xmlResponseCheckService.CheckAuthnContextClassRef(responseXml);
+			_logger.LogTrace("Checked AuthnContextClassRef");
 
-            _xmlResponseCheckService.CheckResponseIssuer(responseXml);
-            _logger.LogTrace("Checked Response Issuer");
+			_xmlResponseCheckService.CheckResponseIssuer(responseXml);
+			_logger.LogTrace("Checked Response Issuer");
 
-            _xmlResponseCheckService.CheckNameID(responseXml);
-            _logger.LogTrace("Checked NameID");
+			_xmlResponseCheckService.CheckNameID(responseXml);
+			_logger.LogTrace("Checked NameID");
 
-            _xmlResponseCheckService.CheckSubjectConfirmation(responseXml);
-            _logger.LogTrace("Checked SubjectConfirmation");
+			_xmlResponseCheckService.CheckSubjectConfirmation(responseXml);
+			_logger.LogTrace("Checked SubjectConfirmation");
 
-            _xmlResponseCheckService.CheckSubjectConfirmationData(responseXml);
-            _logger.LogTrace("Checked SubjectConfirmationData");
+			_xmlResponseCheckService.CheckSubjectConfirmationData(responseXml);
+			_logger.LogTrace("Checked SubjectConfirmationData");
 
-            _xmlResponseCheckService.CheckAssertion(responseXml);
-            _logger.LogTrace("Checked Assertion");
+			_xmlResponseCheckService.CheckAssertion(responseXml);
+			_logger.LogTrace("Checked Assertion");
 
-            _xmlResponseCheckService.CheckConditions(responseXml);
-            _logger.LogTrace("Checked Conditions");
+			_xmlResponseCheckService.CheckConditions(responseXml);
+			_logger.LogTrace("Checked Conditions");
 
-            _xmlResponseCheckService.CheckAttributes(responseXml);
-            _logger.LogTrace("Checked Attributes");
-        }
-    }
+			_xmlResponseCheckService.CheckAttributes(responseXml);
+			_logger.LogTrace("Checked Attributes");
+		}
+	}
 
-    public async Task<bool> CheckSignature(XmlDocument responseXml)
-    {
-        var fullIssuer = responseXml.GetElementsByTagName("Issuer", "*")[0].InnerText;
-        string unprefixedIssuer = fullIssuer;
+	public async Task<bool> CheckSignature(XmlDocument responseXml)
+	{
+		var fullIssuer = responseXml.GetElementsByTagName("Issuer", "*")[0].InnerText;
+		string unprefixedIssuer = fullIssuer;
 		foreach (var prefix in _idpMetadatasOptions.MetadataKeyPrefixes)
 		{
-            unprefixedIssuer = unprefixedIssuer.Replace(prefix, string.Empty);
+			unprefixedIssuer = unprefixedIssuer.Replace(prefix, string.Empty);
 		}
 
-        var metadataUrl = _idpMetadatasOptions.MetadataMapping.GetValueOrDefault(unprefixedIssuer);
+		var metadataUrl = _idpMetadatasOptions.MetadataMapping.GetValueOrDefault(unprefixedIssuer);
 
-        if (string.IsNullOrWhiteSpace(metadataUrl))
-            throw new SPIDValidationException($"{fullIssuer} is an unknown issuer");
+		if (string.IsNullOrWhiteSpace(metadataUrl))
+			throw new SPIDValidationException($"{fullIssuer} is an unknown issuer");
 
-        XmlDocument metadataDocument = new XmlDocument();
-        string metadataXml = null;
-        string cacheKey = $"Metadata_{fullIssuer}";
+		XmlDocument metadataDocument = new XmlDocument();
+		string metadataXml = null;
+		string cacheKey = $"Metadata_{fullIssuer}";
 
-        if (_cache != null)
-        {
-            var metadataXmlFromCache = await _cache.GetStringAsync(cacheKey);
-            if (!string.IsNullOrWhiteSpace(metadataXmlFromCache))
-            {
-                _logger.LogDebug("Metadata for issuer {issuer} retrieved from cache", fullIssuer);
-                metadataXml = metadataXmlFromCache;
-            }
-        }
+		if (_cache != null)
+		{
+			var metadataXmlFromCache = await _cache.GetStringAsync(cacheKey);
+			if (!string.IsNullOrWhiteSpace(metadataXmlFromCache))
+			{
+				_logger.LogDebug("Metadata for issuer {issuer} retrieved from cache", fullIssuer);
+				metadataXml = metadataXmlFromCache;
+			}
+		}
 
-        if (_cache == null || string.IsNullOrWhiteSpace(metadataXml))
-        {
-            using var httpClient = _httpClientFactory.CreateClient();
-            metadataXml = await httpClient.GetStringAsync(metadataUrl);
-            if (_cache != null)
-            {
-                var options = new DistributedCacheEntryOptions()
-                {
-                    AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(_idpMetadatasOptions.CacheAbsoluteExpirationInMins),
-                    SlidingExpiration = null
-                };
-                _logger.LogDebug("Storing metadata for issuer {issuer} in cache", fullIssuer);
-                await _cache.SetStringAsync(cacheKey, metadataXml, options);
-            }
-        }
+		if (_cache == null || string.IsNullOrWhiteSpace(metadataXml))
+		{
+			using var httpClient = _httpClientFactory.CreateClient();
+			metadataXml = await httpClient.GetStringAsync(metadataUrl);
+			if (_cache != null)
+			{
+				var options = new DistributedCacheEntryOptions()
+				{
+					AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(_idpMetadatasOptions.CacheAbsoluteExpirationInMins),
+					SlidingExpiration = null
+				};
+				_logger.LogDebug("Storing metadata for issuer {issuer} in cache", fullIssuer);
+				await _cache.SetStringAsync(cacheKey, metadataXml, options);
+			}
+		}
 
 
-        metadataDocument.LoadXml(metadataXml);
+		metadataDocument.LoadXml(metadataXml);
 
-        var certificates = metadataDocument.GetCertificates();
+		var certificates = metadataDocument.GetCertificates();
 
-        if (!responseXml.IsSigned() || !responseXml.CheckSignature())
-            return false;
+		if (!responseXml.IsSigned() || !responseXml.CheckSignature())
+			return false;
 
-        bool validated = false;
-        foreach (var cert in certificates)
-        {
-            if (responseXml.CheckSignature(cert.GetRSAPublicKey()))
-            {
-                validated = true;
-                break;
-            }
-        }
+		bool validated = false;
+		foreach (var cert in certificates)
+		{
+			if (responseXml.CheckSignature(cert.GetRSAPublicKey()))
+			{
+				validated = true;
+				break;
+			}
+		}
 
-        if (!validated)
-            return false;
+		if (!validated)
+			return false;
 
-        if (!_technicalChecksOptions.SkipAssertionSignatureValidation)
-        {
-            var assertion = responseXml.GetElementsByTagName("Assertion", "*")?[0];
-            if (assertion != null)
-            {
-                XmlDocument assertionDoc = new XmlDocument();
-                assertionDoc.PreserveWhitespace = true;
-                assertionDoc.LoadXml(assertion.OuterXml);
-                if (!assertionDoc.IsSigned() || !assertionDoc.CheckSignature())
-                    return false;
-                validated = false;
+		if (!_technicalChecksOptions.SkipAssertionSignatureValidation)
+		{
+			var assertion = responseXml.GetElementsByTagName("Assertion", "*")?[0];
+			if (assertion != null)
+			{
+				XmlDocument assertionDoc = new XmlDocument();
+				assertionDoc.PreserveWhitespace = true;
+				assertionDoc.LoadXml(assertion.OuterXml);
+				if (!assertionDoc.IsSigned() || !assertionDoc.CheckSignature())
+					return false;
+				validated = false;
 
-                foreach (var cert in certificates)
-                {
-                    if (assertionDoc.CheckSignature(cert.GetRSAPublicKey()))
-                    {
-                        validated = true;
-                        break;
-                    }
-                }
-                if (!validated)
-                    return false;
-            }
-        }
+				foreach (var cert in certificates)
+				{
+					if (assertionDoc.CheckSignature(cert.GetRSAPublicKey()))
+					{
+						validated = true;
+						break;
+					}
+				}
+				if (!validated)
+					return false;
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    public bool ResponseHasBlockingStatusCode(XmlDocument responseXml, out SPIDErrorModel errorModel)
-    {
-        errorModel = null;
+	public bool ResponseHasBlockingStatusCode(XmlDocument responseXml, out SPIDErrorModel errorModel)
+	{
+		errorModel = null;
 
-        var statusCode = responseXml.GetElementsByTagName("StatusCode", "*")[0];
-        var statusCodeValue = statusCode.Attributes["Value"].Value;
-        if (statusCodeValue.Equals(Saml20Constants.StatusCodes.Success))
-            return false;
+		var statusCode = responseXml.GetElementsByTagName("StatusCode", "*")[0];
+		var statusCodeValue = statusCode.Attributes["Value"].Value;
+		if (statusCodeValue.Equals(Saml20Constants.StatusCodes.Success))
+			return false;
 
-        _logger.LogError("StatusCode not Success. StatusCode = {responseStatusCode}", statusCodeValue);
+		_logger.LogError("StatusCode not Success. StatusCode = {responseStatusCode}", statusCodeValue);
 
-        if (string.IsNullOrWhiteSpace(statusCodeValue))
-            throw new SPIDValidationException("StatusCode empty");
+		if (string.IsNullOrWhiteSpace(statusCodeValue))
+			throw new SPIDValidationException("StatusCode empty");
 
-        var statusMessage = responseXml.GetElementsByTagName("StatusMessage", "*")?[0];
+		var statusMessage = responseXml.GetElementsByTagName("StatusMessage", "*")?[0];
 
-        errorModel = new SPIDErrorModel()
-        {
-            StatusCode = new HtmlString(statusCodeValue),
-            StatusMessage = new HtmlString(statusMessage?.InnerText),
-            UserFriendlyMessage = new HtmlString(GetUserFriendlyMessage(statusMessage?.InnerText))
-        };
-        return true;
-    }
+		errorModel = new SPIDErrorModel()
+		{
+			StatusCode = new HtmlString(statusCodeValue),
+			StatusMessage = new HtmlString(statusMessage?.InnerText),
+			UserFriendlyMessage = new HtmlString(GetUserFriendlyMessage(statusMessage?.InnerText))
+		};
+		return true;
+	}
 
-    public string GetUserFriendlyMessage(string statusMessageText)
-    {
-        if (string.IsNullOrWhiteSpace(statusMessageText))
-            return string.Empty;
+	public string GetUserFriendlyMessage(string statusMessageText)
+	{
+		if (string.IsNullOrWhiteSpace(statusMessageText))
+			return string.Empty;
 
-        string[] customErrors = new string[] { "19", "20", "21", "22", "23", "25" };
+		string[] customErrors = new string[] { "19", "20", "21", "22", "23", "25" };
 
-        foreach (var ce in customErrors)
-        {
-            if (statusMessageText.Contains($"nr{ce}"))
-                return _customErrorOptions.Values[$"ErrorCode{ce}Message"];
-        }
+		foreach (var ce in customErrors)
+		{
+			if (statusMessageText.Contains($"nr{ce}"))
+				return _customErrorOptions.Values[$"ErrorCode{ce}Message"];
+		}
 
-        return string.Empty;
-    }
+		return string.Empty;
+	}
 
-    public async Task SignWholeResponseMessageAsync(XmlDocument doc, string responseDigestMethod)
-    {
-        var responseId = doc.DocumentElement.Attributes["ID"].Value;
-        var cert = await _certificateService.GetProxySignCertificate();
-        var signedXml = doc.SignDocument(responseId, cert, responseDigestMethod, _federatorOptions.X509IncludeOption);
+	public async Task SignWholeResponseMessageAsync(XmlDocument doc, string responseDigestMethod)
+	{
+		var responseId = doc.DocumentElement.Attributes["ID"].Value;
+		var cert = await _certificateService.GetProxySignCertificate();
+		var signedXml = doc.SignDocument(responseId, cert, responseDigestMethod, _federatorOptions.X509IncludeOption);
 
-        // Append the computed signature. The signature must be placed as the sibling of the Issuer element.
-        XmlNodeList nodes = doc.DocumentElement.GetElementsByTagName("Status", Saml20Constants.PROTOCOL);
-        nodes[0].ParentNode.InsertBefore(doc.ImportNode(signedXml.GetXml(), true), nodes[0]);
-    }
+		// Append the computed signature. The signature must be placed as the sibling of the Issuer element.
+		XmlNodeList nodes = doc.DocumentElement.GetElementsByTagName("Status", Saml20Constants.PROTOCOL);
+		nodes[0].ParentNode.InsertBefore(doc.ImportNode(signedXml.GetXml(), true), nodes[0]);
+	}
 
-    public async Task SignAssertionAsync(XmlDocument doc, string assertionDigestMethod)
-    {
-        var assertionId = doc.GetElementsByTagName("Assertion", Saml20Constants.ASSERTION)[0].Attributes["ID"].Value;
-        var cert = await _certificateService.GetProxySignCertificate();
-        var signedXml = doc.SignDocument(assertionId, cert, assertionDigestMethod, _federatorOptions.X509IncludeOption);
+	public async Task SignAssertionAsync(XmlDocument doc, string assertionDigestMethod)
+	{
+		var assertionId = doc.GetElementsByTagName("Assertion", Saml20Constants.ASSERTION)[0].Attributes["ID"].Value;
+		var cert = await _certificateService.GetProxySignCertificate();
+		var signedXml = doc.SignDocument(assertionId, cert, assertionDigestMethod, _federatorOptions.X509IncludeOption);
 
-        // Append the computed signature. The signature must be placed as the sibling of the Issuer element.
-        XmlNodeList nodes = doc.DocumentElement.GetElementsByTagName("Issuer", Saml20Constants.ASSERTION);
-        XmlNode assertionNode = nodes[nodes.Count - 1];
-        // may return 2 nodes: Issuer of the response and issuer of the assertion        
-        assertionNode.ParentNode.InsertAfter(doc.ImportNode(signedXml.GetXml(), true), assertionNode);
-    }
+		// Append the computed signature. The signature must be placed as the sibling of the Issuer element.
+		XmlNodeList nodes = doc.DocumentElement.GetElementsByTagName("Issuer", Saml20Constants.ASSERTION);
+		XmlNode assertionNode = nodes[nodes.Count - 1];
+		// may return 2 nodes: Issuer of the response and issuer of the assertion        
+		assertionNode.ParentNode.InsertAfter(doc.ImportNode(signedXml.GetXml(), true), assertionNode);
+	}
+
+	public void ApplyOptionalResponseAlteration(XmlDocument doc)
+	{
+		if (!_optionalResponseAlterationOptions.AlterDateOfBirth)
+			return;
+
+		var attributes = doc.GetElementsByTagName("Attribute", "*"); //some idps use saml2, others saml, hence we use * as namespace
+		XmlNode dateOfBirth = null;
+		foreach (XmlNode node in attributes)
+		{
+			var nameAttr = node.Attributes["Name"];
+
+			if (nameAttr != null && nameAttr.Value == "dateOfBirth")
+			{
+				dateOfBirth = node;
+				break;
+			}
+		}
+
+		if (dateOfBirth == null)
+		{
+			_logger.LogDebug("dateOfBirth attribute not found.");
+			return;
+		}
+
+		var attrValue = dateOfBirth.FirstChild;
+		if (attrValue==null || attrValue.LocalName != "AttributeValue")
+		{
+			_logger.LogDebug("dateOfBirth doesn't contain AttributeValue.");
+			return;
+		}
+
+		var type = attrValue.Attributes["xsi:type"];
+
+		if (type == null)
+		{
+			type = doc.CreateAttribute("xsi:type");
+		}
+
+		type.Value = _optionalResponseAlterationOptions.DateOfBirthFormat;
+		_logger.LogInformation(LoggingEvents.ALTERED_DATEOFBIRTH_TYPE, "dateOfBirth type changed to {dateOfBirthType}.",
+			_optionalResponseAlterationOptions.DateOfBirthFormat);
+	}
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -28,10 +28,6 @@
         "EnableAdaptiveSampling": false
     },
     "AllowedHosts": "*",
-    "webpages:Version": "3.0.0.0",
-    "webpages:Enabled": false,
-    "ClientValidationEnabled": true,
-    "UnobtrusiveJavaScriptEnabled": true,
     "KeyVaultName": "",
     "Certificate": {
         "CertLocation": "ServerRelativeStorage",
@@ -187,5 +183,9 @@
             "Enabled": true,
             "FieldsToLog": "fiscalNumber,email,name,familyName,spidCode"
         }
+    },
+    "OptionalResponseAlteration": {
+        "AlterDateOfBirth": true,
+        "DateOfBirthFormat": "xs:date"
     }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -185,7 +185,7 @@
         }
     },
     "OptionalResponseAlteration": {
-        "AlterDateOfBirth": true,
+        "AlterDateOfBirth": false,
         "DateOfBirthFormat": "xs:date"
     }
 }


### PR DESCRIPTION
CIE and SPID send the dateOfBirth claim with different formats (xs:string vs xs:date). Different SPID idps also send a different type for dateOfBirth.

With this addition to the SPIDProxy we can now normalize the dateOfBirth claim, choosing the type to use. In this way, we can use the same ClaimType in the AAD B2C custom policies, without worrying about discrepancies.

This change is not required nor useful when you use ADFS, since it ignores the type attribute for the AttributeValue.

This feature is disabled by default. You can enable it setting the key _OptionalResponseAlteration__AlterDateOfBirth_ to 'true' and specifying the type via the _OptionalResponseAlteration__OptionalResponseAlteration_ key. Setting the type to 'xs:date' is highly recommended since the B2C custom policies define the dateOfBirth claim as "date".