### PR TITLE
Fix SessionManagement for CIE and CIETest

### DIFF
--- a/AAD B2C/CustomPolicies/TrustFrameworkExtensions.xml
+++ b/AAD B2C/CustomPolicies/TrustFrameworkExtensions.xml
@@ -570,7 +570,7 @@
             <OutputClaim ClaimTypeReferenceId="identityProvider" DefaultValue="CIE Test" />
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="CIE-Base-SAML2" />
-          <UseTechnicalProfileForSessionManagement ReferenceId="SM-Saml-CIE" />
+          <UseTechnicalProfileForSessionManagement ReferenceId="SM-Saml-CIETest" />
         </TechnicalProfile>
         <TechnicalProfile Id="CIE-SAML2">
           <DisplayName>CIE</DisplayName>
@@ -582,7 +582,7 @@
             <OutputClaim ClaimTypeReferenceId="identityProvider" DefaultValue="CIE" />
           </OutputClaims>
           <IncludeTechnicalProfile ReferenceId="CIE-Base-SAML2" />
-          <UseTechnicalProfileForSessionManagement ReferenceId="SM-Saml-CIETest" />
+          <UseTechnicalProfileForSessionManagement ReferenceId="SM-Saml-CIE" />
         </TechnicalProfile>
 
         


### PR DESCRIPTION
Fix SessionManagement for CIE and CIETest as per @Reykrot suggestion in #62

> nel TrustFrameworkExtension i valori di cie e cie-test sono invertiti, a riga 573 e 585 hanno i valori invertiti rispetto al TecnicalProfile di riferimento.