### PR TITLE
Inject User-Agent if enabled in config

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
@@ -19,7 +19,17 @@ if (string.Equals(builder.Configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"], 
 builder.Services.AddRazorPages();
 
 builder.Services.AddApplicationInsightsTelemetry();
-builder.Services.AddHttpClient();
+builder.Services.AddHttpClient("default", client =>
+{
+	bool userAgentEnabled = false;
+	bool.TryParse(builder.Configuration["UserAgent:Enabled"], out userAgentEnabled);
+	if(!userAgentEnabled)
+	{
+		return;
+	}
+	var userAgent = builder.Configuration["UserAgent:Value"];
+	client.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+});
 
 builder.Services.AddControllersWithViews()
 	.AddNewtonsoftJson(options =>

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorResponseService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorResponseService.cs
@@ -121,7 +121,7 @@ public class FederatorResponseService : IFederatorResponseService
 
 		if (_cache == null || string.IsNullOrWhiteSpace(metadataXml))
 		{
-			using var httpClient = _httpClientFactory.CreateClient();
+			using var httpClient = _httpClientFactory.CreateClient("default");
 			metadataXml = await httpClient.GetStringAsync(metadataUrl);
 			if (_cache != null)
 			{

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -190,5 +190,9 @@
     "OptionalResponseAlteration": {
         "AlterDateOfBirth": false,
         "DateOfBirthFormat": "xs:date"
+    },
+    "UserAgent": {
+        "Value": "SPIDProxy/8.0",
+        "Enabled": false
     }
 }


### PR DESCRIPTION
eIDAS seems to have added restrictions on incoming http request towards metadata urls (both test and prod). If no user-agent is specified, requests will fail with a 403 Forbidden.

With this change we can inject a User-Agent in the Http requests made via the HttpClient. The user-agent value is configurable via appsettings. By default the User-Agent is NOT injected.