### PR TITLE
Add cieACS parameter and configuration to disable ACS/SPIDL retrieval from Referer

### DIFF
--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/FederatorRequestExtensions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Extensions/FederatorRequestExtensions.cs
@@ -14,14 +14,14 @@ public static class FederatorRequestExtensions
 
     public static bool IsCIE(this FederatorRequest federatorRequest)
     {
-        return federatorRequest.IdentityProvider.Equals("CIE", StringComparison.InvariantCultureIgnoreCase)
-            || federatorRequest.IdentityProvider.Equals("CIETEST", StringComparison.InvariantCultureIgnoreCase);
+        return federatorRequest.IdentityProvider.Equals("CIE", StringComparison.OrdinalIgnoreCase)
+            || federatorRequest.IdentityProvider.Equals("CIETEST", StringComparison.OrdinalIgnoreCase);
     }
 
     public static bool IsEIDAS(this FederatorRequest federatorRequest)
     {
-        return federatorRequest.IdentityProvider.Equals("EIDAS", StringComparison.InvariantCultureIgnoreCase)
-            || federatorRequest.IdentityProvider.Equals("EIDASTEST", StringComparison.InvariantCultureIgnoreCase);
+        return federatorRequest.IdentityProvider.Equals("EIDAS", StringComparison.OrdinalIgnoreCase)
+            || federatorRequest.IdentityProvider.Equals("EIDASTEST", StringComparison.OrdinalIgnoreCase);
     }
 
     public static int GetAttributeConsumingService(this FederatorRequest federatorRequest,

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/AttributeConsumingServiceOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/AttributeConsumingServiceOptions.cs
@@ -16,4 +16,5 @@ public class AttributeConsumingServiceOptions
 
 	public int CIEAttributeConsumingService { get; set; }
     public int EIDASAttributeConsumingService { get; set; }
+    public bool DisableACSFromReferer { get; set; }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/AttributeConsumingServiceOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/AttributeConsumingServiceOptions.cs
@@ -10,7 +10,10 @@ public class AttributeConsumingServiceOptions
     public int AttributeConsumingServiceDefaultValue { get; set; }
     public bool UpdateAssertionConsumerServiceUrl { get; set; }
     public List<string> ValidACS { get; set; }
-    public string AttrConsServIndexQueryStringParamName { get; set; }
-    public int CIEAttributeConsumingService { get; set; }
+    public List<string> CIEValidACS { get; set; }
+	public string AttrConsServIndexQueryStringParamName { get; set; }
+	public string CIEAttrConsServIndexQueryStringParamName { get; set; }
+
+	public int CIEAttributeConsumingService { get; set; }
     public int EIDASAttributeConsumingService { get; set; }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/SPIDOptions.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Models/Options/SPIDOptions.cs
@@ -17,4 +17,5 @@ public class SPIDOptions
     public string DefaultComparison{ get; set; }
 
     public string ComparisonQueryStringParamName { get; set; }
+    public bool DisableSpidLevelFromReferer { get; set; }
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Program.cs
@@ -52,6 +52,7 @@ builder.Services.Configure<AttributeConsumingServiceOptions>(options => {
 	var acsSection = builder.Configuration.GetSection("attributeConsumingService");
 	acsSection.Bind(options);
 	options.ValidACS = acsSection["validACS"].Split(",").ToList();
+	options.CIEValidACS= acsSection["CIEvalidACS"].Split(",").ToList();
 });
 
 builder.Services.Configure<CertificateOptions>(builder.Configuration.GetSection("Certificate"));

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/ISPIDService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/ISPIDService.cs
@@ -9,12 +9,16 @@ namespace Microsoft.SPID.Proxy.Services;
 
 public interface ISPIDService
 {
-    int GetAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
+	int GetSPIDAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
+	int GetCIEAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
+
 	int GetSPIDLValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString, bool isCie);
 	string GetComparisonValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString, bool isCie);
 	string GetPurposeValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString);
     bool IsSpidLValid(NameValueCollection queryStringCollection, string origin = "");
     bool IsPurposeValid(NameValueCollection queryStringCollection, string origin = "");
-    bool IsACSValid(NameValueCollection queryStringCollection, string origin = "");
-    bool IsComparisonValid(NameValueCollection queryStringCollection, string origin = "");
+	bool IsSPIDACSValid(NameValueCollection queryStringCollection, string origin = "");
+	bool IsCIEACSValid(NameValueCollection queryStringCollection, string origin = "");
+
+	bool IsComparisonValid(NameValueCollection queryStringCollection, string origin = "");
 }

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorRequestService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/FederatorRequestService.cs
@@ -132,12 +132,13 @@ public class FederatorRequestService : IFederatorRequestService
 
         try
         {
-            var attributeConsumingService = federatorRequest.GetAttributeConsumingService(
-                _attributeConsumingServiceOptions.CIEAttributeConsumingService,
+            var attributeConsumingServiceIndex = federatorRequest.GetAttributeConsumingService(
+                _spidService.GetCIEAttributeConsumigServiceValue(refererQueryString,relayQueryString,wctxQueryString),
                 _attributeConsumingServiceOptions.EIDASAttributeConsumingService,
-                _spidService.GetAttributeConsumigServiceValue(refererQueryString, relayQueryString, wctxQueryString)
+                _spidService.GetSPIDAttributeConsumigServiceValue(refererQueryString, relayQueryString, wctxQueryString)
             );
-            requestAsXml.SetAttributeConsumingService(attributeConsumingService);
+
+            requestAsXml.SetAttributeConsumingService(attributeConsumingServiceIndex);
 
             var idenityProviderUrl = _idpService.GetIDPUrl(federatorRequest.IdentityProvider);
             rootEl.SetAttribute("Destination", idenityProviderUrl);

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
@@ -151,22 +151,28 @@ public class SPIDService : ISPIDService
 	public int GetSPIDAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
 	{
 		var ACSValue = _attributeConsumingServiceOptions.AttributeConsumingServiceDefaultValue;
+		if (_attributeConsumingServiceOptions.DisableACSFromReferer)
+		{
+			return ACSValue;
+		}
+
+		string paramName = _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName;
 
 		//check for ACS in referer first, then relaystate, then wctx. If none is found, use default
 		if (IsSPIDACSValid(refererQueryString, "REFERER"))
 		{
-			_logger.LogDebug("Using AttributeConsumingServiceIndex from Referer: {acsValue}", refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-			ACSValue = int.Parse(refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from Referer: {acsValue}", refererQueryString[paramName]);
+			ACSValue = int.Parse(refererQueryString[paramName]);
 		}
 		else if (IsSPIDACSValid(relayQueryString, "RELAYSTATE"))
 		{
-			_logger.LogDebug("Using AttributeConsumingServiceIndex from RelayState: {acsValue}", relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-			ACSValue = int.Parse(relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from RelayState: {acsValue}", relayQueryString[paramName]);
+			ACSValue = int.Parse(relayQueryString[paramName]);
 		}
 		else if (IsSPIDACSValid(wctxQueryString, "WCTX"))
 		{
-			_logger.LogDebug("Using AttributeConsumingServiceIndex from WCTX: {acsValue}", wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
-			ACSValue = int.Parse(wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from WCTX: {acsValue}", wctxQueryString[paramName]);
+			ACSValue = int.Parse(wctxQueryString[paramName]);
 		}
 		else
 		{
@@ -179,6 +185,12 @@ public class SPIDService : ISPIDService
 	public int GetCIEAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
 	{
 		var ACSValue = _attributeConsumingServiceOptions.CIEAttributeConsumingService;
+
+		if (_attributeConsumingServiceOptions.DisableACSFromReferer)
+		{
+			return ACSValue;
+		}
+
 		string paramName = _attributeConsumingServiceOptions.CIEAttrConsServIndexQueryStringParamName;
 
 		//check for ACS in referer first, then relaystate, then wctx. If none is found, use default

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
@@ -74,31 +74,61 @@ public class SPIDService : ISPIDService
 		return true;
 	}
 
-	public bool IsACSValid(NameValueCollection queryStringCollection, string origin = "")
+	public bool IsSPIDACSValid(NameValueCollection queryStringCollection, string origin = "")
 	{
+		string paramName = _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName;
 
 		if (queryStringCollection == null)
 		{
-			_logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: queryString is null", _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin);
+			_logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: queryString is null", paramName, origin);
 			return false;
 		}
 
-		if (string.IsNullOrWhiteSpace(queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]))
+		if (string.IsNullOrWhiteSpace(queryStringCollection[paramName]))
 		{
 			_logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: {AttrConsServIndexQueryStringParamName} key not present",
-				_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin, _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName);
+				paramName, origin, paramName);
 			return false;
 		}
 
-		if (!_attributeConsumingServiceOptions.ValidACS.Contains(queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]))
+		if (!_attributeConsumingServiceOptions.ValidACS.Contains(queryStringCollection[paramName]))
 		{
 			_logger.LogDebug("Checking {AttrConsServIndexQueryStringParamName} in {origin}: {AttrConsServIndexQueryStringParamName} value not valid. Found: {foundAttrConsServIndexQueryStringParamName]}, Expecting one of: [{expectedAttrConsServIndexQueryStringParamName}]",
-				_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, origin, _attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName, queryStringCollection[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName], _attributeConsumingServiceOptions.ValidACS);
+				paramName, origin, paramName, queryStringCollection[paramName], _attributeConsumingServiceOptions.ValidACS);
 			return false;
 		}
 
 		return true;
 	}
+
+	public bool IsCIEACSValid(NameValueCollection queryStringCollection, string origin = "")
+	{
+		string paramName = _attributeConsumingServiceOptions.CIEAttrConsServIndexQueryStringParamName;
+
+		if (queryStringCollection == null)
+		{
+			_logger.LogDebug("Checking {CIEAttrConsServIndexQueryStringParamName} in {origin}: queryString is null", paramName, origin);
+			return false;
+		}
+
+		if (string.IsNullOrWhiteSpace(queryStringCollection[paramName]))
+		{
+			_logger.LogDebug("Checking {CIEAttrConsServIndexQueryStringParamName} in {origin}: {CIEAttrConsServIndexQueryStringParamName} key not present",
+				paramName, origin, paramName);
+			return false;
+		}
+
+		if (!_attributeConsumingServiceOptions.CIEValidACS.Contains(queryStringCollection[paramName]))
+		{
+			_logger.LogDebug("Checking {CIEAttrConsServIndexQueryStringParamName} in {origin}: {CIEAttrConsServIndexQueryStringParamName} value not valid. Found: {foundCIEAttrConsServIndexQueryStringParamName]}, Expecting one of: [{expectedCIEAttrConsServIndexQueryStringParamName}]",
+				paramName, origin, paramName, queryStringCollection[paramName], _attributeConsumingServiceOptions.CIEValidACS);
+			return false;
+		}
+
+		return true;
+	}
+
+
 	public bool IsComparisonValid(NameValueCollection queryStringCollection, string origin = "")
 	{
 
@@ -118,22 +148,22 @@ public class SPIDService : ISPIDService
 		return true;
 	}
 
-	public int GetAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
+	public int GetSPIDAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
 	{
 		var ACSValue = _attributeConsumingServiceOptions.AttributeConsumingServiceDefaultValue;
 
 		//check for ACS in referer first, then relaystate, then wctx. If none is found, use default
-		if (IsACSValid(refererQueryString, "REFERER"))
+		if (IsSPIDACSValid(refererQueryString, "REFERER"))
 		{
 			_logger.LogDebug("Using AttributeConsumingServiceIndex from Referer: {acsValue}", refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
 			ACSValue = int.Parse(refererQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
 		}
-		else if (IsACSValid(relayQueryString, "RELAYSTATE"))
+		else if (IsSPIDACSValid(relayQueryString, "RELAYSTATE"))
 		{
 			_logger.LogDebug("Using AttributeConsumingServiceIndex from RelayState: {acsValue}", relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
 			ACSValue = int.Parse(relayQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
 		}
-		else if (IsACSValid(wctxQueryString, "WCTX"))
+		else if (IsSPIDACSValid(wctxQueryString, "WCTX"))
 		{
 			_logger.LogDebug("Using AttributeConsumingServiceIndex from WCTX: {acsValue}", wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
 			ACSValue = int.Parse(wctxQueryString[_attributeConsumingServiceOptions.AttrConsServIndexQueryStringParamName]);
@@ -145,6 +175,36 @@ public class SPIDService : ISPIDService
 
 		return ACSValue;
 	}
+
+	public int GetCIEAttributeConsumigServiceValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString)
+	{
+		var ACSValue = _attributeConsumingServiceOptions.CIEAttributeConsumingService;
+		string paramName = _attributeConsumingServiceOptions.CIEAttrConsServIndexQueryStringParamName;
+
+		//check for ACS in referer first, then relaystate, then wctx. If none is found, use default
+		if (IsCIEACSValid(refererQueryString, "REFERER"))
+		{
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from Referer: {acsValue}", refererQueryString[paramName]);
+			ACSValue = int.Parse(refererQueryString[paramName]);
+		}
+		else if (IsCIEACSValid(relayQueryString, "RELAYSTATE"))
+		{
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from RelayState: {acsValue}", relayQueryString[paramName]);
+			ACSValue = int.Parse(relayQueryString[paramName]);
+		}
+		else if (IsCIEACSValid(wctxQueryString, "WCTX"))
+		{
+			_logger.LogDebug("Using AttributeConsumingServiceIndex from WCTX: {acsValue}", wctxQueryString[paramName]);
+			ACSValue = int.Parse(wctxQueryString[paramName]);
+		}
+		else
+		{
+			_logger.LogDebug("Using Default AttributeConsumingServiceIndex: {acsValue}", ACSValue);
+		}
+
+		return ACSValue;
+	}
+
 
 	public int GetSPIDLValue(NameValueCollection refererQueryString, NameValueCollection relayQueryString, NameValueCollection wctxQueryString, bool isCie)
 	{

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/Services/Implementations/SPIDService.cs
@@ -210,6 +210,11 @@ public class SPIDService : ISPIDService
 	{
 		var spidL = isCie ? _cieOptions.DefaultSPIDL : _spidOptions.DefaultSPIDL;
 
+		if(_spidOptions.DisableSpidLevelFromReferer)
+		{
+			return spidL;
+		}
+
 		if (IsSpidLValid(refererQueryString, "REFERER"))
 		{
 			_logger.LogDebug("Using spidL from Referer: {spidLValue}", refererQueryString[_spidOptions.SpidLevelQueryStringParamName]);

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -71,7 +71,9 @@
         "AttributeConsumingServiceDefaultValue": 0,
         "UpdateAssertionConsumerServiceUrl": true,
         "ValidACS": "0,1,2",
+        "CIEValidACS": "50,60,70",
         "AttrConsServIndexQueryStringParamName": "spidACS",
+        "CIEAttrConsServIndexQueryStringParamName": "cieACS",
         "CIEAttributeConsumingService": 50,
         "EIDASAttributeConsumingService": 100
     },

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -76,7 +76,8 @@
         "AttrConsServIndexQueryStringParamName": "spidACS",
         "CIEAttrConsServIndexQueryStringParamName": "cieACS",
         "CIEAttributeConsumingService": 50,
-        "EIDASAttributeConsumingService": 100
+        "EIDASAttributeConsumingService": 100,
+        "DisableACSFromReferer": false
     },
 
     "APPINSIGHTS_INSTRUMENTATIONKEY": "",

--- a/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
+++ b/WebApps/Proxy/Microsoft.SPID.Proxy/appsettings.json
@@ -61,7 +61,8 @@
         "PurposeName": "Purpose",
         "SpidLevelQueryStringParamName": "spidL",
         "ComparisonQueryStringParamName": "comparison",
-        "AssertionIssueInstantToleranceMins": 15
+        "AssertionIssueInstantToleranceMins": 15,
+        "DisableSpidLevelFromReferer": false
     },
     "cie": {
         "DefaultSPIDL": 3,


### PR DESCRIPTION
The ACS value for a CIE authentication can now be overriden via cieACS (the name is configurable) parameter in the Referer. It's now also possible to completely disable the retrieval of the ACS and SPIDL from the Referer.