### PR TITLE
Support CNS with missing SN and G in Subject DN

### DIFF
--- a/.github/workflows/cns-pr.yml
+++ b/.github/workflows/cns-pr.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       SOLUTION_FILE: "CNS.Auth.Web.sln"
       PUBLISH_FOLDER: "_publish"
+      ARTIFACT_NAME: CNSProxy
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     defaults:
@@ -36,3 +37,9 @@ jobs:
 
       - name: publish
         run: dotnet publish -c Release -o $PUBLISH_FOLDER $SOLUTION_FILE
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ github.workspace }}/WebApps/CNS.Auth.Web/${{ env.PUBLISH_FOLDER }}

--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,4 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+/WebApps/CNS.Auth.Web/Properties/ServiceDependencies/cnsproxy-mingiustizia-coll - Web Deploy/profile.arm.json

--- a/WebApps/CNS.Auth.Web/Services/CNSCertificateService.cs
+++ b/WebApps/CNS.Auth.Web/Services/CNSCertificateService.cs
@@ -56,25 +56,25 @@ namespace CNS.Auth.Web.Services
 			var subjectRawData = cert.SubjectName.RawData;
 
 			string SN, G;
-
-			if (!cert.Subject.Contains("SN="))
+			
+			if(!cert.Subject.Contains("SN="))
 			{
-				SN = "Unknown";
+				SN = options.SurnamePlaceholder;
 			}
 			else
 			{
-				SN = new AsnEncodedData("SN", subjectRawData).Format(false);
-			}
+                SN = new AsnEncodedData("SN", subjectRawData).Format(false);
+            }
 
-			if (!cert.Subject.Contains("G="))
-			{
-				G = "Unknown";
-			}
-			else
-			{
-				G = new AsnEncodedData("G", subjectRawData).Format(false);
-			}
-
+            if (!cert.Subject.Contains("G="))
+            {
+                G = options.GivenNamePlaceholder;
+            }
+            else
+            {
+                G = new AsnEncodedData("G", subjectRawData).Format(false);
+            }
+			            
 			var OU = new AsnEncodedData("OU", subjectRawData).Format(false);
 			var O = new AsnEncodedData("O", subjectRawData).Format(false);
 			var C = new AsnEncodedData("C", subjectRawData).Format(false);
@@ -226,5 +226,8 @@ namespace CNS.Auth.Web.Services
 		public bool LogCertificate { get; set; } = true;
 		public bool LogSubject { get; set; } = true;
 		public bool BlockIfMissingGivenNameOrSurname { get; set; } = false;
-	}
+		public string GivenNamePlaceholder { get; set; }
+        public string SurnamePlaceholder { get; set; }
+
+    }
 }

--- a/WebApps/CNS.Auth.Web/Services/CNSCertificateService.cs
+++ b/WebApps/CNS.Auth.Web/Services/CNSCertificateService.cs
@@ -226,8 +226,8 @@ namespace CNS.Auth.Web.Services
 		public bool LogCertificate { get; set; } = true;
 		public bool LogSubject { get; set; } = true;
 		public bool BlockIfMissingGivenNameOrSurname { get; set; } = false;
-		public string GivenNamePlaceholder { get; set; }
-        public string SurnamePlaceholder { get; set; }
+		public string GivenNamePlaceholder { get; set; } = "Utente";
+		public string SurnamePlaceholder { get; set; } = "Non disponibile";
 
     }
 }

--- a/WebApps/CNS.Auth.Web/Services/CNSCertificateService.cs
+++ b/WebApps/CNS.Auth.Web/Services/CNSCertificateService.cs
@@ -55,8 +55,26 @@ namespace CNS.Auth.Web.Services
 			Claim commonName = new Claim("commonName", CN);
 			var subjectRawData = cert.SubjectName.RawData;
 
-			var SN = new AsnEncodedData("SN", subjectRawData).Format(false);
-			var G = new AsnEncodedData("G", subjectRawData).Format(false);
+			string SN, G;
+
+			if (!cert.Subject.Contains("SN="))
+			{
+				SN = "Unknown";
+			}
+			else
+			{
+				SN = new AsnEncodedData("SN", subjectRawData).Format(false);
+			}
+
+			if (!cert.Subject.Contains("G="))
+			{
+				G = "Unknown";
+			}
+			else
+			{
+				G = new AsnEncodedData("G", subjectRawData).Format(false);
+			}
+
 			var OU = new AsnEncodedData("OU", subjectRawData).Format(false);
 			var O = new AsnEncodedData("O", subjectRawData).Format(false);
 			var C = new AsnEncodedData("C", subjectRawData).Format(false);

--- a/WebApps/CNS.Auth.Web/appsettings.json
+++ b/WebApps/CNS.Auth.Web/appsettings.json
@@ -28,7 +28,9 @@
 		"TrustedListFileUrl": "https://eidas.agid.gov.it/TL/TSL-IT.xml",
 		"LogCertificate": true,
 		"LogSubject": true,
-		"BlockIfMissingGivenNameOrSurname": false
+		"BlockIfMissingGivenNameOrSurname": false,
+		"GivenNamePlaceholder": "Utente",
+		"SurnamePlaceholder": "Non Disponibile"
 	},
 	"CertificateForwarding": {
 		"CertificateHeaderName": "X-ARR-ClientCert",


### PR DESCRIPTION
Some CNS cards don't have the Surname and GivenName in the subject which causes problems when using the CNS Proxy with AAD B2C. With this PR, when the SN or G field are missing from the Subject DN, placeholder values can be used instead (See CNSCertificate section in appsettings.json).